### PR TITLE
feat: complete Phase 0 spikes, add docs, templates, and release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Catch-all: the project owner reviews everything
+* @kafkade

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: kafkade
+buy_me_a_coffee: kafkade
+patreon: kafkade
+ko_fi: kafkade

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report a bug in kora
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the form below to help us investigate.
+  - type: input
+    id: version
+    attributes:
+      label: kora version
+      description: Run `kora --version` to find this
+      placeholder: "0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: e.g., Ubuntu 24.04, macOS 15.2, Windows 11 23H2
+      placeholder: "Ubuntu 24.04"
+    validations:
+      required: true
+  - type: input
+    id: audio-backend
+    attributes:
+      label: Audio backend (Linux only)
+      description: PipeWire, PulseAudio, or ALSA? Run `pactl info | head -1` or `pw-cli info` to check.
+      placeholder: "PipeWire"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you observe?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Run `kora song.mp3`
+        2. Press space to pause
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+  - type: textarea
+    id: audio-info
+    attributes:
+      label: Audio file details (if applicable)
+      description: Format, codec, sample rate, channels. Run `ffprobe <file>` or share the file extension and source.
+      placeholder: "MP3, 320kbps, 44100Hz, stereo"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Run with `RUST_LOG=debug kora <args>` and paste the output
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information that might help

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or Discussion
+    url: https://github.com/kafkade/kora/discussions
+    about: Ask questions or start a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is this related to a problem?
+      description: A clear description of the problem this would solve
+      placeholder: "I'm frustrated when..."
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the feature
+      description: A clear description of what you'd like to happen
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternatives you've considered
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this relate to?
+      options:
+        - Audio playback (decode, output, quality)
+        - DSP (equalizer, visualizer, effects)
+        - TUI (interface, themes, keybindings)
+        - Providers (local files, radio, podcasts)
+        - Playlists & queue management
+        - Configuration & settings
+        - IPC / remote control
+        - CLI flags & commands
+        - Documentation
+        - Not sure
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information, mockups, or examples

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,10 @@ Providers implement capability-based traits (evolving — do not stabilize until
 - No plugin system before 1.0
 - No mobile app before CLI/TUI has proven architecture
 
+## Git Policy
+
+**Never execute Git commands that modify history or submit code.** This includes `git commit`, `git push`, `git rebase`, `git merge`, `git reset`, `git cherry-pick`, `git revert`, and `git tag`. Read-only commands like `git status`, `git diff`, `git log`, and `git branch` are fine. The maintainer must always review and commit changes themselves.
+
 ## Reference Documents
 
 The full product roadmap with architecture decisions, data model, competitive analysis, and phased milestones is in `ROADMAP.md`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  # Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Description
+
+<!-- What does this PR do? Provide a brief summary of the changes. -->
+
+## Related Issues
+
+<!-- Link related issues: "Closes #123" or "Relates to #456" -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI / infrastructure
+- [ ] Other (describe below)
+
+## Module
+
+<!-- Which modules are affected? Check all that apply. -->
+
+- [ ] `core/` — Domain models, traits, config
+- [ ] `playback/` — Decode, DSP, state machine
+- [ ] `backend/` — Audio output (CPAL)
+- [ ] `providers/` — Audio sources (local, radio, podcast)
+- [ ] `tui/` — Terminal UI
+- [ ] `ipc/` — Remote control
+- [ ] `docs/` — Documentation
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` reports no warnings
+- [ ] `cargo fmt` has been applied
+- [ ] I have added tests for new functionality (if applicable)
+- [ ] I have updated documentation (if applicable)
+- [ ] I have updated CHANGELOG.md (if user-facing changes)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,49 +8,76 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
-  build:
+  validate:
+    name: Validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+
+      - name: Install ALSA (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all-targets
+
+  build:
+    name: Build
+    needs: validate
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install ALSA (Linux only)
-        if: runner.os == 'Linux'
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install ALSA
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
-      - name: Cache cargo
-        uses: actions/cache@v4
+      - name: Build release
+        run: cargo build --release
+
+      - name: Verify binary
+        run: ./target/release/kora --version
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          name: kora-linux
+          path: target/release/kora
+          retention-days: 7
 
-      - name: Build
-        run: cargo build --verbose
-
-      - name: Run tests
-        run: cargo test --verbose
-
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-
-  fmt:
+  ci-pass:
+    name: CI Pass
+    needs: [validate, build]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --check
+      - name: Check results
+        run: |
+          if [ "${{ needs.validate.result }}" != "success" ]; then exit 1; fi
+          if [ "${{ needs.build.result }}" != "success" ]; then exit 1; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install ALSA (Linux native builds)
+        if: runner.os == 'Linux' && !matrix.cross
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Install cross (for cross-compilation)
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build release binary
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+        shell: bash
+
+      - name: Package binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../kora-${{ github.ref_name }}-${{ matrix.target }}.tar.gz kora
+          cd ../../..
+          sha256sum kora-${{ github.ref_name }}-${{ matrix.target }}.tar.gz > kora-${{ github.ref_name }}-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Package binary (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/kora.exe" -DestinationPath "kora-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          $hash = (Get-FileHash "kora-${{ github.ref_name }}-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  kora-${{ github.ref_name }}-${{ matrix.target }}.zip" | Out-File -Encoding ascii "kora-${{ github.ref_name }}-${{ matrix.target }}.zip.sha256"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kora-${{ matrix.target }}
+          path: |
+            kora-*.tar.gz
+            kora-*.zip
+            kora-*.sha256
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Extract release notes from CHANGELOG.md
+        id: extract
+        uses: ffurrer2/extract-release-notes@v2
+
+      - name: Determine pre-release status
+        id: prerelease
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="${VERSION%%.*}"
+          if [ "$MAJOR" = "0" ]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes "${{ steps.extract.outputs.release_notes }}" \
+            ${{ steps.prerelease.outputs.flag }} \
+            artifacts/*
+
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --no-verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Audio pipeline: symphonia decode → rtrb ring buffer → CPAL output
+- Local file playback: MP3, FLAC, OGG Vorbis, Opus, WAV
+- CLI with clap: `kora <file>` plays audio
+- Multi-file queue: play directories and multiple files in sequence
+- Volume control via `--volume` CLI flag
+- Ctrl+C handling for clean shutdown
+- CI pipeline: GitHub Actions for Linux, macOS, Windows
+- Project documentation: ROADMAP.md, ADR-001 through ADR-005
+- Dual MIT + Apache 2.0 licensing
+- Graceful handling of corrupt and truncated audio files (skip bad frames, continue playback)
+- Decode performance reporting in log output (realtime multiplier)
+
+### Fixed
+
+- Audio playback crash caused by unsafe ring buffer Consumer handling in CPAL callback

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <https://github.com/kafkade/anvil/issues>. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,172 @@
+# Contributing to kora
+
+Thank you for your interest in contributing to kora! This document provides guidelines and instructions for contributing to the project.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). Please be respectful and constructive in all interactions.
+
+## How to Contribute
+
+### Reporting Bugs
+
+Before reporting a bug:
+
+1. Check existing [issues](https://github.com/kafkade/kora/issues) to avoid duplicates
+2. Gather relevant information:
+   - kora version (`kora --version`)
+   - Operating system and version
+   - Audio backend (Linux: PipeWire, PulseAudio, or ALSA)
+   - Steps to reproduce
+   - Audio file format and details (if relevant)
+   - Log output (`RUST_LOG=debug kora <args>`)
+
+Use the [bug report template](https://github.com/kafkade/kora/issues/new?template=bug_report.yml) to create an issue.
+
+### Suggesting Features
+
+1. Check existing issues and discussions for similar suggestions
+2. Open a [feature request](https://github.com/kafkade/kora/issues/new?template=feature_request.yml) with:
+   - Clear description of the feature
+   - Use case and motivation
+   - Proposed implementation (if you have ideas)
+
+### Submitting Code
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Run tests (`cargo test`)
+5. Run lints (`cargo clippy -- -D warnings`)
+6. Format code (`cargo fmt`)
+7. Commit with a descriptive message using conventional commits
+8. Push to your fork
+9. Open a Pull Request
+
+## Development Setup
+
+### Prerequisites
+
+- **Rust**: 1.80 or later ([rustup.rs](https://rustup.rs/))
+- **Linux**: ALSA development headers (`sudo apt install libasound2-dev` on Debian/Ubuntu, `sudo dnf install alsa-lib-devel` on Fedora)
+- **macOS**: No extra dependencies (CoreAudio)
+- **Windows**: No extra dependencies (WASAPI)
+
+### Building
+
+```sh
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/kora.git
+cd kora
+
+# Build debug version
+cargo build
+
+# Build release version
+cargo build --release
+
+# Run tests
+cargo test
+
+# Run clippy lints
+cargo clippy -- -D warnings
+
+# Format code
+cargo fmt
+
+# Run with debug logging
+RUST_LOG=debug cargo run -- song.mp3
+```
+
+### Running Tests
+
+```sh
+# Run all tests
+cargo test
+
+# Run a specific test
+cargo test test_name
+
+# Run tests with output
+cargo test -- --nocapture
+```
+
+## Project Structure
+
+```
+kora/
+├── src/
+│   ├── main.rs            # Entry point, CLI parsing
+│   ├── core/              # Domain models, traits, config (no audio deps)
+│   │   ├── track.rs       # Track, TrackMetadata types
+│   │   └── types.rs       # Volume, shared types
+│   ├── playback/          # Decode, DSP, state machine
+│   │   ├── decoder.rs     # symphonia decode pipeline
+│   │   └── engine.rs      # Playback orchestration
+│   ├── backend/           # Audio output adapters
+│   │   └── cpal_backend.rs # CPAL output via rtrb ring buffer
+│   └── providers/         # Audio source implementations
+│       └── local.rs       # Local file resolver
+├── docs/
+│   └── adr/               # Architecture Decision Records
+├── ROADMAP.md             # Full product roadmap
+└── CHANGELOG.md           # Keep a Changelog format
+```
+
+### Key Architecture Decisions
+
+See [docs/adr/](docs/adr/) for Architecture Decision Records documenting key technical decisions.
+
+### Layer Rules
+
+kora follows a strict layered architecture. Please respect these boundaries:
+
+- **core/** — No audio crate dependencies. No TUI dependencies.
+- **playback/** — May depend on symphonia, rtrb. No TUI dependencies.
+- **backend/** — Platform-specific audio output only. No TUI.
+- **providers/** — May depend on core/. No playback internals.
+- **tui/** — May depend on everything above. Not depended on by anything.
+
+### Real-Time Audio Rules
+
+Code running on the CPAL audio callback thread must follow these rules (see ADR-001):
+
+- No heap allocation
+- No blocking I/O
+- No mutex waits — lock-free only
+- No logging — atomic flag checks only
+- Underrun: output silence, set atomic flag
+
+## Coding Standards
+
+- Follow standard Rust conventions and idioms
+- Use `rustfmt` for formatting (default settings)
+- Address all `clippy` warnings
+- Use `thiserror` for error types, `anyhow` for application errors
+- Wrap errors with context (`anyhow::Context`)
+- Add doc comments for public APIs
+- Use table-driven tests where possible
+
+## Commit Messages
+
+Use [conventional commits](https://www.conventionalcommits.org/):
+
+- `feat:` — New feature
+- `fix:` — Bug fix
+- `docs:` — Documentation only
+- `test:` — Adding or updating tests
+- `refactor:` — Code change that neither fixes a bug nor adds a feature
+- `chore:` — Build process, CI, dependencies
+
+Examples:
+
+```
+feat: add internet radio playback via Radio Browser API
+fix: correct audio dropout when seeking near end of track
+docs: add ADR-006 for podcast state management
+test: add golden file tests for MP3 decoder
+```
+
+## License
+
+By contributing to kora, you agree that your contributions will be licensed under the same dual license as the project: MIT OR Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A fast, multi-source terminal audio player built in Rust.
 
 **kora** plays local audio files, internet radio stations, and podcasts from your terminal — with an equalizer, visualizer, themes, and more planned.
 
+### Why "kora"?
+
+The [kora](https://en.wikipedia.org/wiki/Kora_(instrument)) is a 21-string West African harp — one of the most beautiful and versatile acoustic instruments in the world. Built from a calabash gourd, a hardwood neck, and cowhide, it produces a sound often compared to a harp or a flamenco guitar: rich, resonant, and unmistakable.
+
+The name reflects the project's values:
+
+- **Craftsmanship** — the kora is handmade by artisans, each one unique. This player is built with the same care: hand-tuned audio pipeline, no shortcuts.
+- **Versatility** — a single kora covers melody, bass, and rhythm simultaneously. This player handles local files, radio, and podcasts in one tool.
+- **Tradition meets modernity** — the kora is an ancient instrument that thrives in modern music, from Toumani Diabaté to electronic collaborations. This player brings a modern Rust architecture to the timeless act of listening.
+- **Short and distinctive** — four characters, easy to type in a terminal, easy to remember.
+
 ## Quick Start
 
 ```sh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1263,25 +1263,39 @@ Research: Phase 9 (requires PoC gates) --> Phase 10 (requires Phase 9 success)
 
 ---
 
-## SECTION 18: NAMING & BRANDING (OPTIONAL)
+## SECTION 18: NAMING & BRANDING
 
-**Top candidates** (all `[Validation Required]` -- check crates.io, GitHub, domains):
+### Chosen Name: **kora**
 
-| Name | Strengths | Weaknesses |
-|------|-----------|------------|
-| **kora** | Short (4 chars), musical (West African string instrument), distinctive, easy to type | May conflict with existing projects |
-| **cadence** | Musical term (rhythm), elegant, 7 chars | May conflict with Linux Cadence audio tool |
-| **riff** | Musical (guitar riff), short (4 chars), punchy | Very common word, likely conflicts |
-| **forte** | Musical (loud), short (5 chars), strong feel | May conflict |
-| **resonance** | Descriptive, audio-themed, professional | Long to type (9 chars) |
-| **wavelet** | Audio/DSP reference, technical, short-ish | Niche/academic feel |
-| **rustamp** | Clear Rust + Winamp heritage | A bit literal |
-| **oxide** | Rust-themed (iron oxide), short | Overused in Rust ecosystem |
+The [kora](https://en.wikipedia.org/wiki/Kora_(instrument)) is a 21-string West African harp — one of the most beautiful and versatile acoustic instruments in the world. Built from a calabash gourd, a hardwood neck, and cowhide, it produces a sound often compared to a harp or a flamenco guitar: rich, resonant, and unmistakable.
 
-**Recommendation**: **kora** -- Short, distinctive, musical, easy to type, unlikely to conflict.
-`kora play ~/Music/`, `kora status --json`, `kora --theme Nord`.
+**Why this name fits the project:**
 
-**Runner-ups**: **cadence** (if no Linux conflict), **riff** (if crate available).
+| Quality | The Instrument | The Player |
+|---------|---------------|------------|
+| **Craftsmanship** | Handmade by artisans, each one unique | Hand-tuned audio pipeline, no shortcuts |
+| **Versatility** | Covers melody, bass, and rhythm simultaneously | Handles local files, radio, and podcasts in one tool |
+| **Tradition meets modernity** | Ancient instrument thriving in modern music | Modern Rust architecture for the timeless act of listening |
+| **Simplicity** | Elegant in form despite 21 strings | Four characters, easy to type in a terminal |
+
+**Practical evaluation:**
+
+- crates.io: available `[Validated]`
+- GitHub: `kafkade/kora` `[Validated]`
+- Short and terminal-friendly: `kora play ~/Music/`, `kora status --json`, `kora --theme Nord`
+- Pronounceable in all major languages
+- Distinctive — unlikely to be confused with other tools
+
+**Candidates considered and rejected:**
+
+| Name | Reason Rejected |
+|------|----------------|
+| cadence | Conflicts with Linux Cadence audio tool |
+| riff | Very common word, likely namespace conflicts |
+| forte | Generic, common word |
+| resonance | Too long to type (9 chars) |
+| oxide | Overused in Rust ecosystem |
+| rustamp | Too literal, derivative |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,1324 @@
+# 🎵 Product Roadmap — kora
+
+> A comprehensive roadmap for **kora**, a Rust-based cross-platform audio player beginning as a CLI/TUI application. This document covers architecture, features, phasing, legal considerations, and execution strategy for a solo developer working part-time.
+
+---
+
+## SECTION 0: ASSUMPTIONS TABLE & CLARIFYING QUESTIONS
+
+Before the roadmap begins, the following assumptions anchor every decision. Each assumption is stated, defended, and risk-assessed.
+
+| # | Question | Default | Reasoning | Risk if Wrong |
+|---|----------|---------|-----------|---------------|
+| 1 | Team size | Solo developer, part-time, with occasional community PRs | Prompt states intermediate Rust developer, part-time. Roadmap must be ruthlessly scoped. | If a team materializes, phases compress but architecture stays valid. |
+| 2 | Target timeline | Open-ended, milestone-driven (ship when ready) | Solo part-time work is unpredictable. Fixed dates create pressure to cut corners on audio correctness. | Sponsors or users may want predictability — publish phase goals, not dates. |
+| 3 | Budget constraints | Zero budget. No paid APIs, no licensed codecs, no paid infra. Donations welcome. | Open-source, user-sovereign philosophy. Paid dependencies create friction for contributors and users. | Some codecs (AAC) may require ffmpeg as optional runtime dep — acceptable trade-off. |
+| 4 | MVP focus | CLI/TUI exclusively. No web interface until post-1.0. | Principle 6 (Daily Use First). A web UI doubles the frontend surface area before the core is proven. | If web demand is high, the layered architecture allows adding it later without rework. |
+| 5 | Initial distribution | `cargo install` + GitHub Releases (pre-built binaries via cargo-dist). Add Homebrew and AUR post-MVP. | `cargo install` is free, reaches the primary audience (Rust/terminal users), and requires zero infra. Pre-built binaries via cargo-dist cover non-Rust users. | Miss Linux distro package managers initially — acceptable; community can contribute packaging. |
+| 6 | Primary user persona | Terminal Power User | This persona will adopt first, give feedback, and contribute. Other personas are served in later phases. | If the wedge persona is wrong, the project still works as a personal tool. |
+| 7 | Primary wedge & switching trigger | Terminal Power User switching from cmus/mpv because they want streaming sources + modern TUI + Rust reliability in one tool. | cmus is minimal (no streaming), mpv is not music-focused, ncmpcpp requires MPD. A unified player fills the gap. | If terminal users don't switch, the project remains useful as the developer's personal player. |
+| 8 | Marketing positioning | "No tracking. No accounts. Your music, your way." — lead with user sovereignty and open-source. | Privacy-conscious users are the natural audience for a terminal audio player. Differentiates from Spotify/Apple Music. | May limit mainstream appeal — acceptable; mainstream is not the initial target. |
+| 9 | Top 3 acquisition channels | 1) GitHub trending / r/rust, 2) Hacker News, 3) Reddit r/commandline + r/unixporn | Terminal tools go viral on HN and Reddit. Rust community is supportive of new projects. | Growth may be slow — acceptable for a solo project. Quality > marketing. |
+| 10 | MVP audio formats | Tier 1 (MVP): MP3, FLAC, OGG Vorbis, Opus, WAV/PCM — all via symphonia (pure Rust). | symphonia decodes all five natively with no C dependencies. Covers 95%+ of local music libraries. [Validated] | If a user's library is mostly AAC/M4A, they must wait for post-MVP ffmpeg integration. |
+| 11 | Hi-res / audiophile | CD quality (44.1kHz/16-bit) and below for MVP. Support up to 192kHz/24-bit if symphonia handles it, but no bit-perfect/exclusive mode claims until measured. | Audiophile features are a rabbit hole. Most users won't notice. Defer exclusive mode to post-1.0. | Lose audiophile niche — acceptable; they have foobar2000 and dedicated hardware players. |
+| 12 | Audio output backend | CPAL as the sole audio output abstraction for all native platforms (Linux ALSA/PipeWire, macOS CoreAudio, Windows WASAPI). | CPAL is the de facto Rust audio output crate, actively maintained, supports all three desktop OSes. Avoids maintaining three platform-specific backends. [Validated] | CPAL may have edge cases (device switching, suspend/resume) — mitigate with PoC gate (Section 9.1). |
+| 13 | Gapless playback | Deferred to Phase 3 (Audio Polish). Not MVP. | Gapless requires pre-decoding and careful buffer management. MVP should focus on reliable single-track playback first. | Album listeners notice gaps — acceptable trade-off for faster MVP. |
+| 14 | ReplayGain | Deferred to Phase 3. | Requires metadata parsing + gain application in DSP chain. Not essential for daily use. | Volume jumps between tracks — minor annoyance, not a blocker. |
+| 15 | Radio directory | Radio Browser API as primary. Custom TOML stations as secondary/fallback. | Radio Browser is free, open, community-run, 30k+ stations, REST API, multiple mirrors. [Validation Required] — verify rate limits and uptime. | If Radio Browser goes down, custom TOML stations still work. User is never locked out. |
+| 16 | Podcast scope (initial) | Simple "paste RSS URL and play" for Phase 2. Full podcast client in Phase 4. | A full podcast client (OPML, episode tracking, downloads) is a product in itself. Phase 2 should prove network audio works; Phase 4 builds the full experience. | Podcast users may find Phase 2 too limited — acceptable; Phase 4 follows. |
+| 17 | Spotify integration | Research only. Do not commit engineering time until ToS/API feasibility is validated. | Spotify's Web API does NOT provide raw audio streams for third-party playback. The Connect SDK has restrictive terms. [Validation Required] — Spotify Developer ToS for open-source players. | If Spotify is infeasible, the project still serves local + radio + podcast + open server users. |
+| 18 | YouTube integration | Research only. yt-dlp as optional runtime dependency if pursued. High ToS risk. | YouTube ToS explicitly prohibit downloading/ripping. yt-dlp operates in a legal grey area. [Validation Required] — legal counsel recommended before shipping. | If YouTube is dropped, the project still has strong value from other sources. |
+| 19 | WASM/Web audio | Research phase (Phase 9). Web Audio API + AudioWorklet is technically viable but has latency constraints and CORS limitations for streaming URLs. [Validation Required] | WASM audio is an emerging area. Prototype must validate decode performance and streaming feasibility before commitment. | If web target is impractical, CLI + native apps still serve all core personas. |
+| 20 | Apple platform FFI | UniFFI as the recommended Rust → Swift bridging tool. Prototype required before commitment. | UniFFI generates Swift bindings automatically from Rust, maintained by Mozilla. [Validation Required] — verify async callback delivery and iOS static library packaging. | If UniFFI fails, manual cbindgen is the fallback (more maintenance, but proven). |
+| 21 | Desktop app framework | Tauri v2 when/if a desktop GUI is built. | Tauri is Rust-native, lighter than Electron, has native system tray and updater. | Tauri's webview rendering may have quirks — acceptable risk for post-1.0 feature. |
+
+---
+
+## SECTION 1: USER PERSONAS
+
+### 1. Terminal Power User — "Alex"
+- **Archetype**: Software engineer, lives in tmux + Neovim, keyboard-only workflow
+- **Listening**: Indie rock, electronic, lo-fi. Local FLAC library (~3k files) + internet radio for background. 2–6 hour sessions.
+- **Tech comfort**: Expert. Writes shell scripts, customizes everything.
+- **Platforms**: Linux (primary), macOS (secondary). Terminal exclusively.
+- **Pain point**: cmus has no streaming; mpv isn't music-focused; ncmpcpp requires MPD setup. Wants one tool for local + radio + podcasts.
+- **Accessibility**: None specific. Values fast keyboard navigation.
+- **Roadmap phases**: **Phase 0–2** (core target from day one)
+
+### 2. Podcast Commuter — "Sam"
+- **Archetype**: Knowledge worker, listens to 8+ podcasts weekly during commute and chores
+- **Listening**: Tech podcasts, news, interview shows. 30–90 min sessions, daily.
+- **Tech comfort**: Moderate. Uses terminal occasionally, prefers polished UX.
+- **Platforms**: Laptop (CLI), wants iOS eventually.
+- **Pain point**: Apple Podcasts sync is unreliable. Wants open-source, cross-device podcast management with speed control and resume.
+- **Accessibility**: Needs playback speed control (1.5x–2x).
+- **Roadmap phases**: **Phase 4** (full podcast client), **Phase 10** (iOS)
+
+### 3. Music Collector — "Jordan"
+- **Archetype**: Audiophile-adjacent, large organized library, cares about tags and lossless
+- **Listening**: Jazz, classical, progressive rock. Full albums, gapless critical. 15k+ files, FLAC/ALAC.
+- **Tech comfort**: High. Comfortable with CLI but wants library browsing.
+- **Platforms**: Linux/macOS desktop.
+- **Pain point**: No terminal player handles large libraries well with proper gapless, EQ, and tag browsing.
+- **Accessibility**: None specific.
+- **Roadmap phases**: **Phase 3** (gapless, EQ), **Phase 6** (library management)
+
+### 4. Casual Listener — "Riley"
+- **Archetype**: Developer who wants background music while coding. Minimal configuration.
+- **Listening**: Lo-fi streams, jazz radio, ambient playlists. All-day background sessions.
+- **Tech comfort**: Moderate. Uses terminal but doesn't want to configure much.
+- **Platforms**: macOS/Linux terminal.
+- **Pain point**: Wants a "just works" terminal radio player with nice visuals. Existing tools require too much setup.
+- **Accessibility**: None specific. Values beautiful defaults.
+- **Roadmap phases**: **Phase 2** (radio), **Phase 3** (visualizer, themes)
+
+### 5. Multi-Device User — "Morgan"
+- **Archetype**: Uses laptop at desk (CLI), phone on the go, wants continuity
+- **Listening**: Mix of podcasts and music. Switches devices 3–4 times daily.
+- **Tech comfort**: High.
+- **Platforms**: macOS CLI → iOS → possibly Apple Watch.
+- **Pain point**: No open-source player syncs state across CLI and mobile.
+- **Accessibility**: None specific.
+- **Roadmap phases**: **Phase 10** (iOS app, sync server)
+
+### 6. Developer/Contributor — "Casey"
+- **Archetype**: Rust developer interested in audio programming, wants to contribute or build plugins
+- **Listening**: Varies. Uses the player partly to explore the codebase.
+- **Tech comfort**: Expert. Reads source code for fun.
+- **Platforms**: Any.
+- **Pain point**: Most audio players have opaque C/C++ codebases. Wants clean Rust with good docs and contribution paths.
+- **Accessibility**: None specific.
+- **Roadmap phases**: **Phase 5** (IPC/API), **Phase 8** (plugin system)
+
+### 7. Radio Enthusiast — "Kai"
+- **Archetype**: Discovers and bookmarks internet radio stations across genres and countries
+- **Listening**: World music, jazz, classical, electronic radio. Long sessions, station-hopping.
+- **Tech comfort**: Moderate to high.
+- **Platforms**: Linux/macOS terminal.
+- **Pain point**: No good terminal radio browser with favorites, metadata display, and a large station directory.
+- **Accessibility**: None specific.
+- **Roadmap phases**: **Phase 2** (radio integration), **Phase 3** (favorites)
+
+---
+
+## SECTION 2: CROSS-PLATFORM ARCHITECTURE & ENGINE DESIGN
+
+### 2.1 — Layered Core Architecture
+
+The architecture is four layers with strict dependency rules:
+
+**Layer 1: Domain Core** (`core` crate)
+- Compiles to: native (all OS), WASM, FFI-safe
+- Contains: Track/Playlist/Queue models, Provider trait definitions, Session state, Configuration model (serde + TOML), Metadata types (not extraction), EQ preset model, Theme model
+- Dependencies: serde, toml, uuid — no audio, no TUI, no platform crates
+- All types must be `Send + Sync` and FFI-representable where needed
+- All APIs synchronous (no async runtime dependency)
+
+**Layer 2: Playback Core** (`playback` crate)
+- Compiles to: native (all OS), potentially WASM with limitations
+- Contains: Audio decode pipeline (format detection → codec dispatch → sample conversion), DSP chain (EQ biquad filters, volume, ReplayGain gain, crossfade mixing, FFT for visualizer data), Playback state machine (play/pause/stop/seek/next/prev), Metadata extraction (ID3v2, Vorbis comments, MP4 atoms via lofty)
+- Dependencies: `core`, symphonia, rubato (resampling), lofty (metadata), realfft (FFT)
+- Does NOT depend on: cpal, any platform audio output, TUI, network, async runtime
+- Internal sample format: f32 throughout the DSP chain (sufficient precision, hardware-friendly)
+- Exposes a pull-based API: the audio backend calls `playback.fill_buffer(&mut [f32])` to get samples
+- Thread model: decode runs on a dedicated worker thread, pushes samples into a lock-free ring buffer. DSP processing happens either on the decode thread (pre-buffer) or on the audio callback thread (post-buffer). **Recommendation**: DSP on the decode thread, so the audio callback only reads from the ring buffer. This keeps the callback path trivially simple.
+
+**Layer 3: Audio Backend Adapters** (one crate per platform)
+- `backend-cpal`: CPAL for Linux/macOS/Windows. Implements `AudioOutput` trait. Runs the audio callback that pulls from the ring buffer.
+- `backend-web` (future): Web Audio API / AudioWorklet for WASM target.
+- `backend-avfoundation` (future): AVAudioEngine for iOS/macOS native apps if CPAL is insufficient.
+- Common trait:
+```rust
+trait AudioOutput: Send {
+    fn start(&mut self, config: AudioConfig) -> Result<()>;
+    fn stop(&mut self);
+    fn set_volume(&mut self, volume_db: f32);
+    fn sample_rate(&self) -> u32;
+    fn device_name(&self) -> &str;
+}
+```
+
+**Layer 4: Frontend Adapters** (each a separate binary/crate)
+- `cli` crate: TUI (ratatui + crossterm) — the main binary for MVP
+- `daemon` (future): headless IPC server, no TUI
+- `web-ui` (future): WASM + web framework
+- `app-shell` (future): SwiftUI consuming FFI bindings
+
+**Boundary rules**:
+- Domain core has zero audio dependencies. It can be used by any frontend for playlist management, config, state.
+- Playback core has zero platform dependencies. It can be tested with a mock output.
+- Audio backends are the ONLY place platform-specific audio code lives.
+- Frontend adapters are the ONLY place UI code lives.
+- No layer may depend on a layer above it.
+
+### 2.2 — Crate/Module Architecture
+
+**Recommendation: Start as a single crate with clear module boundaries. Split into workspace crates at Phase 2.**
+
+**Reasoning**: Premature crate separation in Rust means longer compile times (each crate is a separate compilation unit), more boilerplate (pub exports, feature flags), and friction when APIs are still evolving. A single crate with `mod core`, `mod playback`, `mod backend`, `mod tui` enforces the same boundaries via module visibility (`pub(crate)`) while allowing rapid iteration.
+
+**Split trigger**: When the first non-TUI consumer appears (IPC daemon, Phase 5), extract `core` and `playback` into workspace crates. The module boundaries established in Phase 0–1 become crate boundaries.
+
+**Target workspace layout (Phase 2+)**:
+```
+project/
+├── crates/
+│   ├── core/            # Domain core: models, traits, config, state
+│   ├── playback/        # Decode, DSP, state machine
+│   ├── backend-cpal/    # CPAL audio output
+│   ├── providers/
+│   │   ├── local/       # Local file provider
+│   │   ├── radio/       # Internet radio provider
+│   │   └── podcast/     # Podcast RSS provider
+│   ├── cli/             # TUI application binary
+│   └── ipc/             # IPC protocol (Phase 5)
+├── config/              # Example configs, default themes
+├── tests/               # Integration tests, golden files
+└── docs/                # User and developer documentation
+```
+
+**Rejected alternatives**:
+- Multi-crate from day one: too much overhead for a solo developer in early phases
+- Single crate forever: doesn't support the cross-platform vision; multiple binaries need shared libraries
+
+### 2.3 — Audio Pipeline Architecture
+
+```
+Source → Decoder → Sample Rate Converter → DSP Chain → Ring Buffer → Audio Callback → Output Device
+           │                                    │
+     [Decode Thread]                    [Decode Thread]       [Audio Callback Thread]
+                                             │
+                                    ┌────────┴────────┐
+                                    │ Volume (f32 mul) │
+                                    │ EQ (biquad bank) │
+                                    │ ReplayGain       │
+                                    │ Crossfade         │
+                                    │ FFT → viz buffer  │
+                                    └─────────────────┘
+```
+
+**Stage details**:
+
+| Stage | Thread | Crate | Sample Format | Buffering | Notes |
+|-------|--------|-------|---------------|-----------|-------|
+| Source read (file/network) | I/O thread (async for network, sync for files) | providers | bytes | Tokio for HTTP, std::fs for local | Network uses reqwest with streaming body |
+| Decode | Decode worker thread | playback (symphonia) | i16/i32/f32 → convert to f32 | symphonia's internal buffering | One decoder instance per track |
+| Sample rate conversion | Decode worker thread | playback (rubato) | f32 | Rubato's internal buffers | Only when source rate ≠ output rate |
+| DSP chain | Decode worker thread | playback | f32 | In-place processing on decode buffer | EQ, volume, gain — all applied before ring buffer |
+| FFT for visualizer | Decode worker thread | playback (realfft) | f32 | Writes to shared atomic/lock-free viz buffer | Read-only by TUI thread |
+| Ring buffer | Shared (lock-free) | playback | f32 | Fixed-size ring buffer (~200ms) | Producer: decode thread. Consumer: audio callback. |
+| Audio callback | Audio callback thread (OS-managed) | backend-cpal | f32 → device format | CPAL's internal buffer | Copies from ring buffer. NOTHING else. |
+
+**Seeking**: Decode thread flushes the ring buffer, seeks in the decoder, refills. Brief silence (~50ms) is acceptable for MVP. Gapless improvement in Phase 3.
+
+**Gapless playback (Phase 3)**: Pre-decode next track's first buffer while current track is in its final ~2 seconds. Swap decoders seamlessly. No crossfade for gapless (that's a separate feature).
+
+### 2.3.1 — Real-Time Audio Safety Rules
+
+**Hard rules for the audio callback thread** (the CPAL callback):
+
+1. **No heap allocation** — no `Vec::push`, `String::new`, `Box::new`, `format!()`
+2. **No blocking I/O** — no file reads, no network, no `println!`
+3. **No mutex locks** — use `try_lock` with silent fallback, or lock-free structures only
+4. **No channel receives that block** — use `try_recv` only
+5. **No logging** — at most an atomic flag check for error signaling
+6. **No metadata parsing** — all metadata is resolved before samples reach the ring buffer
+7. **Bounded ring buffer only** — fixed capacity, pre-allocated at startup
+
+**Backpressure strategy**: If the ring buffer is empty (decode can't keep up), output silence and set an atomic `underrun` flag. The UI thread reads this flag and displays a warning. The decode thread detects the underrun and increases its priority/reduces DSP load if possible.
+
+**Overrun handling**: If the ring buffer is full (decode is faster than playback), the decode thread blocks on the ring buffer's `push` (this is fine — the decode thread is allowed to block). This naturally rate-limits decoding to playback speed.
+
+**Underrun recovery**: After an underrun, the decode thread fills the buffer to 50% capacity before the callback resumes reading, preventing oscillation.
+
+### 2.4 — Platform Compilation Targets
+
+| Platform | Target | Audio Output | UI | FFI | Phase |
+|----------|--------|-------------|-----|-----|-------|
+| Linux x86_64/aarch64 | native | CPAL (ALSA/PipeWire) | ratatui | N/A | MVP |
+| macOS x86_64/aarch64 | native | CPAL (CoreAudio) | ratatui | N/A | MVP |
+| Windows x86_64 | native | CPAL (WASAPI) | ratatui (crossterm) | N/A | MVP |
+| Web/WASM | wasm32-unknown-unknown | Web Audio API | Custom (WASM) | wasm-bindgen | Research (Phase 9) |
+| iOS | aarch64-apple-ios | AVAudioEngine | SwiftUI | UniFFI | Moonshot (Phase 10) |
+| macOS App | native | CoreAudio/CPAL | SwiftUI/Tauri | UniFFI | Research (Phase 9) |
+| watchOS | arm64_32-apple-watchos | WKAudioSession | WatchKit | UniFFI | Moonshot (Phase 10) |
+
+### 2.5 — State Management & Persistence
+
+**Recommendation: TOML for configuration and session state. SQLite for library index (Phase 6+).**
+
+**Reasoning**: TOML is human-readable, version-control-friendly, and aligns with Principle 5 (User Sovereignty). For MVP through Phase 5, all state fits comfortably in TOML files. SQLite is introduced only when the library index needs queryable, structured storage (Phase 6).
+
+**State files**:
+- `config.toml` — user preferences, provider settings, keybindings, paths
+- `session.toml` — current playback state (track, position, queue, volume, EQ, theme)
+- `playlists/` — directory of `.toml` playlist files
+- `stations.toml` — custom radio station bookmarks/favorites
+- `podcasts.toml` — subscribed feeds and episode state (upgrades to SQLite in Phase 6)
+
+**Platform paths**:
+- Linux: `$XDG_CONFIG_HOME/kora/` (default `~/.config/kora/`)
+- macOS: `~/Library/Application Support/kora/`
+- Windows: `%APPDATA%\kora\`
+
+**Resume-on-restart**: On quit (or crash), `session.toml` is written with current state. On startup, if `session.toml` exists and `--no-resume` is not passed, restore playback state. Auto-save every 30 seconds during playback.
+
+### 2.6 — Sync Strategy
+
+**Phase 1 (MVP through 1.0)**: All state is local. Config and playlists are portable TOML files. Users sync manually via cloud drives (iCloud Drive, Syncthing, Google Drive).
+
+**Phase 2 (Post-1.0) Recommendation: File-based sync via cloud drives with conflict detection.**
+
+**Reasoning**: A sync server is a second product. CRDTs are over-engineering for this use case. File-based sync with last-modified timestamps and simple conflict detection (prompt user on conflict) covers 90% of multi-device use cases. The migration path: TOML files → TOML files with embedded version vectors → optional sync server (Phase 10).
+
+**Sync classification per entity**:
+
+| Entity | Sync? | Conflict Strategy | Device-Local? | Contains Secrets? | Has Local Paths? |
+|--------|-------|-------------------|---------------|-------------------|------------------|
+| UserConfig | Yes | Last-write-wins | Partially (device-specific audio settings) | No | Yes (library paths) |
+| Playlists | Yes | Merge (track list union) | No | No | Yes (file paths — use provider IDs instead) |
+| Favorites | Yes | Merge (union) | No | No | No (provider IDs) |
+| Session state | No | N/A | Yes | No | Yes |
+| Podcast subscriptions | Yes | Merge (union) | No | No | No |
+| Episode play state | Yes | Last-write-wins (latest position) | No | No | No |
+| EQ presets | Yes | Last-write-wins | No | No | No |
+| Themes | Yes | Last-write-wins | No | No | No |
+| Provider credentials | No (per-device) | N/A | Yes | Yes | No |
+| Listening history | Yes (append-only) | Merge (union) | No | No | No |
+| Library index | No (rebuilt per device) | N/A | Yes | No | Yes |
+
+---
+
+## SECTION 3: PROVIDER SYSTEM ARCHITECTURE
+
+### 3.1 — Provider Trait Design
+
+**Recommendation: Capability-based trait design with async methods. Internal and evolvable — NOT a public stable ABI.**
+
+The provider interface starts as a set of capability traits. A provider implements only the traits matching its capabilities:
+
+```rust
+// All provider methods are async (network I/O) and return Result types
+#[async_trait]
+trait ProviderInfo {
+    fn id(&self) -> &str;            // "local", "radio", "podcast"
+    fn display_name(&self) -> &str;
+    fn capabilities(&self) -> Capabilities; // bitflags
+}
+
+#[async_trait]
+trait Browsable: ProviderInfo {
+    async fn browse(&self, path: &BrowsePath, pagination: Pagination) 
+        -> Result<BrowsePage>;
+}
+
+#[async_trait]
+trait Searchable: ProviderInfo {
+    async fn search(&self, query: &str, pagination: Pagination) 
+        -> Result<SearchResults>;
+}
+
+#[async_trait]
+trait Resolvable: ProviderInfo {
+    async fn resolve(&self, track_id: &TrackId) -> Result<AudioStreamHandle>;
+}
+
+#[async_trait]
+trait MetadataProvider: ProviderInfo {
+    async fn metadata(&self, track_id: &TrackId) -> Result<TrackMetadata>;
+}
+```
+
+**Design decisions**:
+- Async throughout (even local files — for consistency and future network providers)
+- Pagination on browse/search (providers have different page sizes)
+- `AudioStreamHandle` is an enum: `FileHandle(PathBuf)` for local, `HttpStream(Url)` for network
+- Error types are provider-specific but implement a common error trait
+- Cancellation via `tokio::CancellationToken` passed to long-running operations
+- Timeout configurable per-provider in config
+
+**Why not one big trait**: Local files don't need auth. Radio doesn't need search (the directory does). Podcasts don't support browse-by-genre the same way. Small traits compose better.
+
+**Stabilization rule**: Do NOT freeze the provider API until local, radio, and podcast providers are all implemented and the shared patterns are empirically validated. Target API freeze at 1.0.
+
+### 3.2 — Provider Implementation Matrix
+
+| Provider | Auth | Browse | Search | Stream | Metadata | Offline | Phase |
+|----------|------|--------|--------|--------|----------|---------|-------|
+| Local Files | None | Directory tree | Filename + tag search | File read | ID3/Vorbis/MP4 via lofty | Full | MVP |
+| Internet Radio | None | Radio Browser API | Station search | HTTP/ICY stream | ICY metadata | No | Phase 2 |
+| Podcasts (RSS) | None | Feed list | Episode search | HTTP download/stream | RSS metadata | Download cache | Phase 2 (basic), Phase 4 (full) |
+| Navidrome/Subsonic | Subsonic auth | Albums/Artists | Full catalog | Subsonic stream | Subsonic API | Cache | Phase 7 |
+| Jellyfin | API key | Library | Full catalog | Jellyfin stream | Jellyfin API | No | Phase 7 |
+| Plex | OAuth | Library | Full catalog | Plex stream | Plex API | No | Phase 7 |
+| Spotify | OAuth | Library/Playlists | Full catalog | ⛔ No raw audio via Web API | Spotify API | No | Research |
+| YouTube | yt-dlp (runtime) | N/A | yt-dlp search | yt-dlp stream | yt-dlp metadata | No | Research |
+
+### 3.3 — Provider-Specific Concerns
+
+**Local Files Provider**:
+- Data flow: `PathBuf → std::fs::File → symphonia::MediaSource → decode pipeline`
+- Buffering: symphonia handles internal read buffering. Ring buffer between decode and output.
+- Error handling: File not found → skip and log. Corrupt file → skip with user notification. Permission denied → clear error message.
+- Metadata: Read on first play or scan, cached in memory. Written to library index (Phase 6).
+- Offline: Always works.
+
+**Internet Radio Provider**:
+- Data flow: `URL → reqwest streaming GET → ICY-aware byte parser → symphonia decode`
+- Buffering: 5-second pre-buffer before playback starts. Adaptive rebuffering on underrun.
+- Error handling: Connection drop → retry 3x with exponential backoff → notify user. Invalid stream → clear error. Redirect → follow up to 5 hops.
+- Metadata: ICY metadata parsed inline from stream (title, artist if available). Station metadata from Radio Browser API.
+- Offline: Not available. Show last-known station list from cache.
+
+**Podcast Provider**:
+- Data flow: `RSS URL → feed-rs parse → episode URL → reqwest download/stream → symphonia decode`
+- Buffering: For streaming: same as radio. For downloaded episodes: same as local files.
+- Error handling: Feed parse error → show error, keep stale data. Download failure → retry with resume. Episode gone (404) → mark unavailable.
+- Metadata: From RSS feed XML (title, description, duration, pub date, image URL).
+- Offline: Downloaded episodes play offline. Feed list cached locally.
+
+### 3.4 — Radio Provider Deep Dive
+
+| Source | API Type | Station Count | Free? | Rate Limits | Reliability | Recommendation |
+|--------|----------|---------------|-------|-------------|-------------|----------------|
+| Radio Browser | REST JSON | 30k+ | Yes, open source | Generous (no auth needed) | Community-run, multiple mirrors | ✅ **Primary** |
+| radio.garden | Unofficial scraping | Global | [Validation Required] — no public API documented | Unknown | [Validation Required] | ❌ Reject — no stable API, scraping risk |
+| Curated TOML | Local file | User-defined | Yes | N/A | Full user control | ✅ **Secondary** (always available) |
+| TuneIn | Commercial API | Large | [Validation Required] — likely requires partnership | [Validation Required] | Commercial, reliable | ❌ Reject — likely requires commercial agreement |
+
+**Recommendation**: Radio Browser API as the primary station directory. Custom TOML stations as a persistent secondary source that works offline and supplements the directory. Users add favorites from Radio Browser or manually enter station URLs in their `stations.toml`.
+
+**Coexistence model**: The radio browser shows two sources in the TUI: "Directory" (Radio Browser) and "My Stations" (TOML). Users can browse the directory and star stations, which copies them to My Stations. My Stations is always available offline.
+
+### 3.5 — Podcast Provider Deep Dive
+
+**Phase 2 (Basic)**: Paste RSS URL → parse with `feed-rs` → list episodes → stream playback. No persistence of episode state beyond session.
+
+**Phase 4 (Full Client)**:
+- **RSS/Atom parsing**: `feed-rs` crate — handles RSS 2.0, Atom, and JSON Feed. 🟢 [Validated]
+- **OPML import/export**: `opml` crate or simple custom XML serializer (OPML is trivial XML). 🟢
+- **Episode state tracking**: played/in-progress (with position)/new. Stored in `podcasts.toml` initially, SQLite in Phase 6.
+- **Download management**: Background downloads via tokio tasks. Configurable storage limit (e.g., 5GB). Auto-cleanup: delete played episodes older than N days. Resume interrupted downloads (HTTP Range headers).
+- **Playback speed**: 0.5x–3x. See Section 4.1 for pitch correction approach.
+- **Chapter support**: Parse MP3 chapters (ID3v2 CHAP/CTOC frames) and podcast namespace `<podcast:chapters>`. Display chapter list in TUI. 🟡
+- **Apple Podcasts directory**: [Validation Required] — Apple provides an iTunes Search API that can find podcasts. Free, no auth, but undocumented rate limits. Use for discovery only.
+- **Pocket Casts**: [Validation Required] — no public API. Likely not viable. Reject.
+
+---
+
+## SECTION 3A: MEDIA RIGHTS, PROVIDER LEGALITY & TRUST BOUNDARIES
+
+### 3A.1 — DRM and Streaming Provider Reality Check
+
+| Provider | Raw Audio Access | Official SDK? | Open Source Allowed? | ToS Risk | Classification |
+|----------|-----------------|---------------|---------------------|----------|----------------|
+| Spotify | ⛔ Web API returns metadata only, no audio streams. Connect SDK controls Spotify app, doesn't provide raw audio. [Validation Required] | Spotify Connect SDK (limited) | [Validation Required] — Connect SDK ToS restrict open-source redistribution | High | ⛔ Not viable for independent playback |
+| YouTube / YT Music | Via yt-dlp only (no official audio SDK). YouTube ToS §5.1 prohibits downloading. [Validation Required] | No | No official support | High | 🔴 High risk — functional but legally grey |
+| SoundCloud | Via yt-dlp or unofficial API. [Validation Required] | [Validation Required] | [Validation Required] | Medium | 🔴 High risk |
+| Apple Music | DRM-protected streams. MusicKit on Apple platforms only. [Validation Required] | MusicKit (Apple platforms only) | Apple platform apps only | High | ⛔ Not viable for CLI/cross-platform |
+| Navidrome/Subsonic | Open Subsonic API, user's own server, raw audio access | Open API | Yes | 🟢 Low | 🟢 Fully viable |
+| Plex | Plex API provides audio streams to authenticated clients. [Validation Required] — verify third-party client policy | Official API | [Validation Required] | Medium | 🟡 Likely viable with API compliance |
+| Jellyfin | Open API, open source server, raw audio access | Open API | Yes | 🟢 Low | 🟢 Fully viable |
+| Internet Radio | Direct HTTP streams, publicly available | N/A | Yes | 🟢 Low | 🟢 Fully viable |
+| Podcasts (RSS) | Direct HTTP downloads, RSS is open standard | N/A | Yes | 🟢 Low | 🟢 Fully viable |
+
+**Strategic conclusion**: Focus engineering effort on 🟢 providers (local, radio, podcasts, Subsonic/Navidrome, Jellyfin). Treat Spotify/YouTube as Research — validate before committing any engineering time. Never build features that require DRM circumvention.
+
+### 3A.2 — Copyright and Content Risk
+
+| Feature | Legal Status | Risk | Recommendation |
+|---------|-------------|------|----------------|
+| Lyrics fetching/display | Most lyrics are copyrighted. LRCLIB provides community-contributed synced lyrics. [Validation Required] — LRCLIB terms | Medium | Opt-in feature. Use LRCLIB. Cache locally. Display attribution. Never bundle lyrics. |
+| Album art fetching/caching | Varies. Cover art from local files (embedded) is fine. Fetching from external sources needs attribution. | Low–Medium | Embedded art: always display. External fetch: use MusicBrainz Cover Art Archive (free, CC-licensed). |
+| Podcast episode downloads | RSS publishers explicitly provide download URLs. Downloading is intended behavior. | Low | ✅ Safe. Respect `<itunes:block>` if present. |
+| Stream recording ("save to disk") | Recording radio streams may violate station ToS or copyright. | High | ❌ Do NOT build stream recording. Explicitly listed as a non-goal. |
+| YouTube extraction via yt-dlp | YouTube ToS prohibit it. yt-dlp legality is contested. | High | Research only. If shipped, make it a clearly opt-in plugin, not a default feature. Disclose risk to users. |
+| "Now playing" metadata sharing | Song title/artist is factual information. Sharing is fine. | Low | ✅ Safe. |
+
+### 3A.3 — Metadata Exposure & Privacy Matrix
+
+| Data/Metadata | Who Can See It | Risk Level | Mitigation |
+|---|---|---|---|
+| Local file paths | Only the local player process | None | No exposure |
+| Podcast feed URLs requested | Feed host, DNS provider, ISP | Medium | Cache feeds locally; refresh intervals configurable |
+| Radio station stream requests | Station server, ISP | Low–Medium | Normal network behavior — documented in privacy statement |
+| Lyrics search queries | LRCLIB API | Medium | Opt-in only; cache locally after first fetch |
+| Radio Browser API queries | Radio Browser mirrors | Low | Public directory queries; no user identity sent |
+| Last.fm/ListenBrainz scrobbles | Scrobble service | High (full listening history) | Opt-in only, explicit consent required in config |
+| Discord Rich Presence | Discord, Discord friends | Medium | Opt-in only, off by default |
+| yt-dlp requests | YouTube/Google | High | Clearly disclosed; user initiates each request |
+| Crash reports/logs | Maintainer | Medium | Never automatic. User must manually copy/share logs |
+
+### 3A.4 — Credential & Token Storage
+
+**Recommendation: OS keychain as primary, with explicit insecure plaintext fallback.**
+
+- **Linux**: `libsecret` (GNOME Keyring) or `kwallet` (KDE) via `keyring` crate [Validated]
+- **macOS**: macOS Keychain via `keyring` crate [Validated]
+- **Windows**: Windows Credential Manager via `keyring` crate [Validated]
+- **Fallback**: If no keychain is available (headless server, minimal Linux), offer plaintext file storage with explicit warning: "Credentials will be stored in plaintext at <path>. Continue? [y/N]"
+- **Web**: Browser `localStorage`/`sessionStorage` (future, Phase 9)
+- **iOS**: iOS Keychain via the Swift layer (future, Phase 10)
+
+Provider tokens are stored as `provider:<provider_id>:token` keys in the keychain. Never stored in `config.toml`.
+
+### 3A.5 — Non-Goals & Red Lines
+
+Explicitly, this project will NOT:
+
+1. ❌ Circumvent DRM or content protection of any kind
+2. ❌ Download/rip from subscription streaming services without explicit API support
+3. ❌ Collect telemetry, analytics, or usage data — not even opt-in (no infra to receive it)
+4. ❌ Store provider credentials in plaintext config by default
+5. ❌ Build a plugin system before core playback is stable and in daily use (post-1.0)
+6. ❌ Build mobile apps before the CLI/TUI has proven architecture and real users
+7. ❌ Build a sync server before the local state model is stable
+8. ❌ Claim bit-perfect or audiophile quality until independently measured
+9. ❌ Implement a self-update mechanism before package-manager distribution is established
+10. ❌ Require an account, login, or internet connection for local file playback
+11. ❌ Build stream recording / "save to disk" for radio or streaming sources
+12. ❌ Record or transmit any user behavior without explicit user action
+
+---
+## SECTION 4: CORE FEATURE SET
+
+### 4.1 — Audio Playback Engine
+
+**Format Support Tier List**:
+
+| Format | Decoder | Patent/License | Native Rust? | Phase | Complexity | Notes |
+|--------|---------|---------------|-------------|-------|------------|-------|
+| MP3 | symphonia | Expired patents (2017) | Yes | MVP | 🟢 | Universal format. [Validated] |
+| FLAC | symphonia | Free, open standard | Yes | MVP | 🟢 | Lossless standard. [Validated] |
+| OGG Vorbis | symphonia | Free, open standard | Yes | MVP | 🟢 | Common in games/Linux. [Validated] |
+| Opus | symphonia | Free, BSD-licensed | Yes | MVP | 🟢 | Modern, efficient. [Validated] |
+| WAV/PCM | symphonia | No IP | Yes | MVP | 🟢 | Trivial decode. [Validated] |
+| AAC (M4A) | symphonia (partial) / ffmpeg | Patent pool (some expired). [Validation Required] | Partial | Phase 3 | 🟡 | symphonia has experimental AAC. Fallback to ffmpeg as optional runtime dep. |
+| ALAC | symphonia | Apple open-sourced (Apache 2.0) | Partial | Phase 3 | 🟡 | symphonia support [Validation Required]. Fallback to ffmpeg. |
+| WMA | ffmpeg only | Microsoft proprietary | No | Post-1.0 | 🔴 | Requires ffmpeg. Low priority. |
+| APE | ffmpeg only | Free but niche | No | Post-1.0 | 🟡 | Monkey's Audio. Niche format. |
+
+**Gapless Playback** 🟡 (Phase 3):
+- Pre-decode next track's first ~200ms while current track's final ~2 seconds play
+- Seamless buffer swap in the ring buffer (no silence gap, no click)
+- Requires knowing the next track in queue before current track ends
+
+**Seeking** 🟢 (MVP):
+- Absolute seek: jump to position (seconds or percentage)
+- Relative seek: skip ±5s, ±30s (configurable)
+- Flush ring buffer on seek, refill from new position
+- Brief silence (~30–50ms) during seek is acceptable for MVP
+
+**Playback Speed Control** 🔴 (Phase 3):
+- Simple approach (MVP compromise): resample to change speed — this WILL change pitch. Acceptable for podcasts where pitch shift at 1.25x–1.5x is tolerable.
+- Proper approach (Phase 3): pitch-preserving time-stretch via WSOLA (Waveform Similarity Overlap-Add) algorithm. **Recommendation**: Use the `rubato` crate for resampling and implement a basic WSOLA in Rust. If too complex, use `soundtouch` C library via FFI as a fallback. [Validation Required] — rubato's suitability for time-stretch vs pure resampling.
+- Range: 0.5x–3.0x with pitch correction. No pitch correction below 0.5x or above 3.0x.
+
+**Volume Control** 🟢 (MVP):
+- dB-based: -60dB (silence) to +12dB (boost), 0dB = unity gain
+- Applied as f32 multiplication in the DSP chain: `sample *= 10.0f32.powf(gain_db / 20.0)`
+- Smooth ramping (fade over ~10ms) to avoid clicks on volume change
+
+**Mono Downmix** 🟢 (MVP):
+- Toggle in config and via keybinding
+- `mono_sample = (left + right) * 0.5`
+
+### 4.2 — 10-Band Graphic Equalizer 🟡 (Phase 3)
+
+**Band frequencies** (ISO standard): 31Hz, 62Hz, 125Hz, 250Hz, 500Hz, 1kHz, 2kHz, 4kHz, 8kHz, 16kHz
+
+**Implementation**: Bank of 10 biquad peaking EQ filters in series, applied in the DSP chain on the decode thread. Each filter has configurable gain (-12dB to +12dB). Filter coefficients recalculated on gain change (cheap operation).
+
+**Presets** (shipped defaults):
+Flat, Rock, Pop, Jazz, Classical, Electronic, Hip Hop, Acoustic, Bass Boost, Treble Boost, Vocal, Podcast (voice clarity), Custom (user-defined)
+
+**Real-time adjustment**: Changing EQ gain updates filter coefficients. The decode thread picks up new coefficients on the next buffer cycle (~5ms latency). No playback interruption.
+
+**TUI display**: Vertical bars for each band, adjustable with arrow keys. Visual feedback of current gain per band.
+
+**Persistence**: Active preset saved in `session.toml`. Custom presets saved in `config.toml`.
+
+### 4.3 — Spectrum Visualizer 🟡 (Phase 3)
+
+**Modes**:
+- **Bars**: 32–64 frequency bins rendered as vertical bars. Classic spectrum analyzer. 🟢
+- **Wave**: Waveform oscilloscope — renders raw sample amplitude over time. 🟢
+- **Spectrogram**: Scrolling time × frequency heatmap. 🟡 (more complex rendering)
+- Future: Matrix rain, particle effects (plugin-extensible)
+
+**FFT pipeline**: The decode thread computes FFT on the most recent ~2048 samples using `realfft` crate (pure Rust, fast). FFT magnitude data is written to a shared lock-free buffer (e.g., `arc-swap` or atomic array). The TUI thread reads this buffer at its own refresh rate.
+
+**Refresh rate**: 20–30 FPS for TUI (configurable). The FFT is computed at decode rate (~44100/2048 ≈ 21 Hz for 2048-sample windows), which naturally matches TUI refresh.
+
+**Performance constraint**: Visualizer computation is on the decode thread (not the audio callback). TUI rendering is on the UI thread. Neither affects the audio callback. If TUI rendering is slow, frames are dropped — audio continues unaffected.
+
+### 4.4 — Synced Lyrics 🟡 (Phase 3)
+
+- **LRC parsing**: Custom parser (LRC format is trivial: `[mm:ss.xx]lyric line`). No crate needed. 🟢
+- **Embedded lyrics**: Extract from ID3v2 `USLT`/`SYLT` tags and Vorbis `LYRICS` comment via lofty. 🟢
+- **Auto-scroll**: TUI lyrics panel highlights the current line based on playback position. 🟢
+- **External fetch**: LRCLIB API for community-contributed synced lyrics. [Validation Required] — verify LRCLIB API terms, availability, and rate limits. Opt-in feature. 🟡
+- **Podcast chapters**: Display chapter titles in the lyrics panel position for podcast episodes. 🟢
+
+### 4.5 — Playlist Management 🟢 (MVP for basic, 🟡 for full)
+
+**MVP (Phase 1)**: Queue from CLI args (`player song1.mp3 song2.flac dir/`). Basic next/prev/shuffle/repeat.
+
+**Full (Phase 2+)**:
+- **TOML playlists**: Native format. Human-editable. Stored in `playlists/` directory.
+- **M3U/M3U8 import/export**: Parse with a simple custom parser (M3U is trivial). 🟢
+- **PLS import/export**: Similar simplicity. 🟢
+- **Operations**: Create, rename, delete, reorder tracks, duplicate playlist.
+- **Queue**: Separate from playlist. "Play next" inserts at queue head. "Add to queue" appends.
+- **Shuffle**: True random (Fisher-Yates), shuffle-no-repeat (full cycle before repeating).
+- **Repeat**: Off, repeat all, repeat one.
+- **TUI**: Scrollable playlist panel with search/filter within playlist.
+
+### 4.6 — Themes & Visual Customization 🟢 (Phase 2)
+
+**Theme format**: TOML file defining named colors for each UI element.
+
+**Shipped themes (10+)**: Nord, Catppuccin (Mocha, Latte), Gruvbox (Dark, Light), Tokyo Night, Rosé Pine, Dracula, Solarized (Dark, Light), One Dark, Monokai, Default Dark, Default Light.
+
+**Hot-swap**: Cycle themes with a keybinding (e.g., `T`). Theme applied immediately — no restart.
+
+**Custom themes**: User creates `.toml` files in `themes/` config directory. Auto-discovered on startup.
+
+**Theme elements**: background, foreground, primary accent, secondary accent, progress bar (filled/empty), EQ bars (active/inactive), visualizer colors (gradient), border, selection highlight, status bar bg/fg, error color, warning color.
+
+### 4.7 — Session Persistence & Resume 🟢 (MVP)
+
+**Recommendation: TOML for session files.**
+
+Saved state:
+- Current track identifier (file path or URL)
+- Playback position (seconds, f64)
+- Queue contents and order
+- Volume (dB)
+- Active EQ preset name
+- Visualizer mode
+- Active theme name
+- Shuffle/repeat state
+- Paused/playing state
+
+**Auto-save**: Every 30 seconds and on graceful quit. On crash: last auto-save is recovery point (max 30s lost).
+
+**Named sessions** (Phase 3): Save/load named sessions (e.g., "work", "commute", "bedtime"). Default unnamed session is always auto-saved.
+
+### 4.8 — User Configuration 🟢 (MVP)
+
+**File**: `config.toml` in platform-specific config directory.
+
+```toml
+[audio]
+default_volume = -6       # dB
+buffer_ms = 200           # ring buffer size in ms
+# output_device = "default"
+
+[ui]
+theme = "nord"
+visualizer = "bars"
+# compact = false
+
+[providers]
+enabled = ["local", "radio", "podcast"]
+
+[providers.local]
+library_paths = ["~/Music", "/mnt/nas/music"]
+
+[providers.radio]
+directory = "radio-browser"   # or "custom-only"
+
+[keybindings]
+play_pause = "space"
+next = "n"
+prev = "p"
+volume_up = "+"
+volume_down = "-"
+quit = "q"
+```
+
+**Validation**: On startup, parse and validate config with clear error messages pointing to the specific invalid field. Unknown fields are warnings (forward compatibility), not errors.
+
+**CLI override**: Every config value can be overridden via CLI flag for the session. CLI flags take precedence over config file.
+
+### 4.9 — IPC Remote Control 🟡 (Phase 5)
+
+**Protocol**: Unix domain socket on Linux/macOS. Named pipe on Windows. JSON-RPC 2.0 message format.
+
+**Architecture**: The player process runs an IPC server (tokio task). CLI subcommands act as thin clients:
+```bash
+player pause                    # send pause command
+player status --json            # query current state
+player queue add song.mp3       # add to queue
+player volume -3                # adjust volume by -3dB
+```
+
+**Commands**: play, pause, toggle, stop, next, prev, seek (absolute/relative), volume (absolute/relative), status, queue (list/add/remove/clear), playlist (load/save), shuffle, repeat, eq-preset, theme, visualizer.
+
+**Status response** (JSON):
+```json
+{
+  "state": "playing",
+  "track": {"title": "Song", "artist": "Artist", "path": "/music/song.flac"},
+  "position": 127.4,
+  "duration": 312.0,
+  "volume_db": -6,
+  "eq_preset": "flat",
+  "shuffle": false,
+  "repeat": "off"
+}
+```
+
+### 4.10 — Media Key & System Integration 🟡 (Phase 5)
+
+- **Linux MPRIS**: D-Bus `org.mpris.MediaPlayer2` interface via `mpris-server` crate. Integrates with `playerctl`, GNOME/KDE media controls, Polybar, Waybar. 🟢 [Validated]
+- **macOS NowPlaying**: `MPNowPlayingInfoCenter` via objc bindings or `souvlaki` crate. System media keys, Control Center, Touch Bar. 🟡 [Validation Required] — verify souvlaki macOS support
+- **Windows**: Global media keys via `souvlaki` crate. [Validation Required]
+
+### 4.11 — CLI Flags & Per-Session Overrides 🟢 (MVP, expanded over phases)
+
+Built with `clap` v4 derive macros. Key flags:
+```
+player [OPTIONS] [FILES/URLS...]
+
+Options:
+  --volume <dB>          Override volume (-60 to +12)
+  --shuffle              Enable shuffle
+  --repeat <MODE>        off|all|one
+  --mono                 Mono downmix
+  --theme <NAME>         Override theme
+  --eq-preset <NAME>     Override EQ preset
+  --visualizer <MODE>    bars|wave|spectrogram|off
+  --compact              Constrained-width mode
+  --no-resume            Don't restore previous session
+  --config <PATH>        Alternative config file
+  -h, --help             Show help
+  -V, --version          Show version
+
+Subcommands (Phase 5 — IPC):
+  status                 Show current playback status
+  pause / play / toggle  Control playback
+  next / prev            Track navigation
+  volume <dB>            Set/adjust volume
+  queue <SUBCOMMAND>     Queue management
+```
+
+---
+
+## SECTION 5: FEATURES THE USER MAY HAVE MISSED
+
+| # | Feature | Why It Matters | Phase | Complexity |
+|---|---------|---------------|-------|------------|
+| 1 | **File Browser** — in-player directory navigation for discovering and queuing local files | Core UX for local files. Without it, users must specify every file path on CLI. | Phase 2 | 🟢 |
+| 2 | **Bookmark / Favorites System** — star tracks, stations, podcast episodes | Personalization. Quick access to preferred content across sessions. | Phase 2 | 🟢 |
+| 3 | **Last.fm / ListenBrainz Scrobbling** — social listening history | Community feature, free marketing (profile pages link to player). Opt-in only. | Phase 6 | 🟡 |
+| 4 | **ReplayGain / Volume Normalization** — consistent volume across tracks | Prevents jarring volume changes between tracks from different albums/sources. | Phase 3 | 🟡 |
+| 5 | **Crossfade** — smooth transitions between tracks | Enhances casual listening. Configurable duration (0–12 seconds). | Phase 3 | 🟡 |
+| 6 | **Audio Device Selection** — switch output devices at runtime | Users with multiple audio devices (speakers, headphones, DAC) need this. | Phase 3 | 🟡 |
+| 7 | **Sleep Timer** — auto-stop after N minutes | Essential for bedtime listening. Trivial to implement. | Phase 2 | 🟢 |
+| 8 | **Album Art in Terminal** — render via Sixel, Kitty protocol, or Unicode blocks | Visual appeal. Makes the player feel polished. Kitty protocol for supported terminals, fallback to none. | Phase 3 | 🟡 |
+| 9 | **Shell Completions** — bash, zsh, fish, PowerShell | UX polish for terminal users. Auto-generated by `clap` v4. | Phase 2 | 🟢 |
+| 10 | **Man Page Generation** — auto-generated from CLI definition | Standard Unix distribution practice. `clap_mangen` crate. | Phase 5 | 🟢 |
+| 11 | **Headless/Daemon Mode** — run without TUI, controlled via IPC | Enables background playback, scripting, and remote control use cases. | Phase 5 | 🟡 |
+| 12 | **Discord Rich Presence** — show currently playing in Discord status | Popular with younger users. Opt-in. `discord-rpc` crate. | Phase 6 | 🟢 |
+| 13 | **Smart Playlists** — auto-generated from rules (genre, recently added, most played) | Power feature for large libraries. Requires library index (Phase 6). | Phase 6 | 🟡 |
+| 14 | **Listening Statistics** — play counts, listening time, genre distribution | Personal insights. "Your year in music" style reports. Requires listening history data. | Phase 6 | 🟡 |
+| 15 | **Accessibility / High Contrast Themes** — screen reader hints, accessible color schemes | Inclusive design. High contrast themes are easy; screen reader support in TUI is harder. | Phase 5 | 🟡 |
+
+---
+
+## SECTION 6: MUSIC LIBRARY MANAGEMENT (Phase 6 — Future)
+
+### 6.1 — Library Scanning & Indexing 🟡
+
+- **Scanner**: Walk configured directories recursively. Extract metadata via `lofty` for each audio file.
+- **Index**: SQLite database with FTS5 extension for full-text search across title, artist, album, genre.
+- **Schema**: `tracks(id, path, title, artist, album, genre, year, track_num, duration_ms, format, file_size, modified_at, scanned_at)`
+- **Incremental re-scan**: Compare file `modified_at` timestamps. Only re-read metadata for changed files.
+- **File watcher**: `notify` crate for filesystem change detection (inotify on Linux, FSEvents on macOS, ReadDirectoryChangesW on Windows). 🟢 [Validated]
+- **Performance**: Target 100k+ files indexed. SQLite handles this easily. Initial scan of 10k files should complete in <30 seconds.
+
+### 6.2 — Library Browsing 🟡
+
+- Browse by: artist → albums → tracks, album (grid/list), genre, year, recently added, most played
+- Search: FTS5 query across all metadata fields. Sub-100ms response for 100k library.
+- Album view: Track list with metadata, album art (if available), total duration.
+
+### 6.3 — Tag Management 🟡
+
+- **Read**: All formats via `lofty`. [Validated]
+- **Write**: `lofty` supports writing tags for MP3 (ID3v2), FLAC (Vorbis comments), OGG, MP4. [Validated]
+- **Batch edit**: Select multiple tracks → set common fields (artist, album, genre, year).
+- **MusicBrainz auto-tag**: [Validation Required] — MusicBrainz API is free with rate limits (1 req/sec). Use acoustic fingerprinting via `chromaprint` (C library, FFI) for identification. 🔴 (FFI complexity)
+
+### 6.4 — Architecture Consideration
+
+The library index is a **separate module** within the local files provider. It does NOT live in the domain core (it's provider-specific — only local files have a filesystem index). The library module exposes `Browsable` and `Searchable` traits that the local files provider delegates to. Playlists reference tracks by a stable `TrackId` (content hash or path-based) that works whether the library is indexed or not.
+
+---
+
+## SECTION 7: PLUGIN & EXTENSION SYSTEM (Post-1.0 — Phase 8)
+
+**Prerequisite**: Core playback must be stable and in daily use. Internal APIs must be settled. Do not build this until Phase 6 is complete.
+
+### 7.1 — Plugin Architecture
+
+| Runtime | Language | Sandboxing | Performance | Ecosystem | Recommendation |
+|---------|----------|-----------|-------------|-----------|----------------|
+| Lua (mlua) | Lua 5.4 | Moderate (restrict stdlib) | Good | Mature, proven in games/tools | ✅ **Primary** |
+| WASM (wasmtime) | Any→WASM | Excellent (capability-based) | Good | Growing | Runner-up — consider as secondary |
+| Rhai | Rhai | Good | Good | Small | ❌ Too niche, limited community |
+| Native (dylib) | Rust/C | None | Best | N/A | ❌ No sandboxing — security risk |
+| Python (PyO3) | Python | Weak | Moderate | Large | ❌ Heavy runtime, poor sandboxing |
+
+**Recommendation: Lua via `mlua` crate as the primary plugin runtime.** Lua is lightweight (~200KB runtime), fast, proven for embedding (Neovim, Redis, game engines), and `mlua` is well-maintained. Sandboxing is achieved by not exposing `os`, `io`, `debug` standard library modules by default — plugins must request permissions in their manifest.
+
+**Future secondary**: WASM via `wasmtime` for complex plugins that need language-agnostic compilation. Add only after Lua plugin ecosystem is established.
+
+### 7.2 — Plugin API Surface
+
+Plugins can:
+- **Subscribe to events**: `on("track.change", fn)`, `on("playback.pause", fn)`, `on("app.quit", fn)`
+- **Read state**: `player.current_track()`, `player.position()`, `player.volume()`, `player.eq_bands()`
+- **Register commands**: `register_command("scrobble", fn)` — accessible via IPC
+- **Register keybindings**: `register_key("ctrl+l", fn)` — with permission
+- **Make HTTP requests**: `http.get(url)`, `http.post(url, body)` — requires `network` permission
+- **File I/O**: `fs.read(path)`, `fs.write(path, data)` — sandboxed to `plugins/<name>/data/`
+- **Set timers**: `set_timeout(fn, ms)`, `set_interval(fn, ms)`
+- **Log**: `log.info(msg)`, `log.error(msg)` — written to `plugins/<name>/log.txt`
+
+**Security**: Permission manifest in `plugin.toml`:
+```toml
+[plugin]
+name = "lastfm-scrobbler"
+version = "0.1.0"
+permissions = ["network", "events.track.change"]
+```
+
+### 7.3 — Plugin Distribution 🟡
+
+- Plugins in `~/.config/kora/plugins/<name>/`
+- Each plugin: `plugin.toml` (manifest) + `main.lua` (entry point) + optional data files
+- CLI management: `player plugins install <github-url>`, `player plugins list`, `player plugins remove <name>`
+- Future: community plugin registry on project website
+
+---
+
+## SECTION 8: MOONSHOT FEATURES
+
+### 8.1 — Web Interface 🔴 (Phase 9 — Research)
+
+- **Engine**: Compile playback core to WASM. Decode in WASM, output via AudioWorklet.
+- **Frontend recommendation: Leptos** (Rust-native WASM framework). Keeps the entire stack in Rust, simplifies build pipeline, leverages Rust expertise. Alternative: Svelte (lighter JS bundle, better ecosystem) — choose based on developer preference.
+- **Modes**: Standalone (local files via File API, streaming via fetch) and Remote Control (WebSocket to running CLI instance).
+- **Limitations**: CORS restrictions on radio stream URLs. Some radio stations don't send CORS headers — would need a proxy. [Validation Required]
+- **PWA**: Service worker for offline support, installable as web app.
+
+### 8.2 — Native macOS/iOS App 🔴 (Phase 10 — Moonshot)
+
+- **FFI**: Rust core compiled as static library, exposed via UniFFI-generated Swift bindings.
+- **iOS features**: Background audio (`AVAudioSession`), Lock Screen controls (`MPNowPlayingInfoCenter`), CarPlay (audio app template), Home Screen widget.
+- **macOS features**: Menu bar player (mini player in menu bar), native notifications, Handoff.
+- **Apple Watch**: Now Playing complication, basic transport controls (play/pause/skip). Extremely limited — audio processing happens on paired iPhone. [Validation Required] — watchOS audio streaming capabilities.
+- **iCloud sync**: Sync config, playlists, favorites, podcast state via iCloud Key-Value Store or CloudKit.
+
+### 8.3 — Desktop App (Tauri v2) 🟡 (Phase 9 — Research)
+
+- Tauri wraps the web frontend (Leptos/Svelte) with native audio backend (CPAL, not Web Audio).
+- System tray with mini player controls.
+- Global hotkeys via Tauri's API.
+- Native file system access (no File API limitations).
+- Auto-update via Tauri's built-in updater.
+
+### 8.4 — Self-Hosted Sync Server 🔴 (Phase 10 — Moonshot)
+
+- Lightweight Rust server (axum + SQLite).
+- REST API for CRUD on playlists, favorites, podcast state, listening history, config.
+- No audio data stored — metadata and state only.
+- Docker image for easy self-hosting.
+- Authentication: simple token-based auth (no OAuth complexity for self-hosted).
+- Future: act as podcast episode cache proxy.
+
+### 8.5 — Social & Sharing 🟡 (Phase 6+)
+
+- **Last.fm/ListenBrainz**: Scrobble API integration. Opt-in, configured per-provider in config. `rustfm-scrobble` crate or direct API calls. 🟢
+- **Discord Rich Presence**: Show track info in Discord. `discord-rpc` crate. Opt-in. 🟢
+- **Share "Now Playing"**: Copy formatted text to clipboard. 🟢
+- **Collaborative playlists** and **public profiles**: Require sync server. Phase 10.
+
+---
+
+## SECTION 9: TECH STACK RECOMMENDATIONS
+
+| Component | Recommendation | Justification | Alternatives Rejected |
+|-----------|---------------|---------------|----------------------|
+| **Language** | Rust (stable channel) | Memory safety, zero-cost abstractions, excellent concurrency, growing audio ecosystem | Go (cliamp's choice — no zero-cost DSP, GC pauses risk audio glitches), C++ (unsafe, harder to contribute to), Zig (immature ecosystem) |
+| **Audio Decoding** | symphonia | Pure Rust, no C deps, supports MP3/FLAC/OGG/Opus/WAV/AAC(experimental). Actively maintained. [Validated] | ffmpeg bindings (C dependency, complex build), gstreamer (heavy, Linux-centric), rodio (uses symphonia internally but hides control) |
+| **Audio Output** | cpal | De facto Rust audio output. Supports ALSA, PipeWire, CoreAudio, WASAPI. Actively maintained. [Validated] | rodio (higher-level, less control over buffer management), platform-specific (3x maintenance) |
+| **DSP / EQ** | Custom biquad filters (in-house) | Biquad EQ filters are well-documented (~50 lines of code per filter). No crate needed. Full control over the DSP chain. | dasp (too general), external DSP library (unnecessary dependency for biquad filters) |
+| **Sample Rate Conversion** | rubato | Pure Rust, high quality (sinc interpolation), async resampling API fits the pipeline. [Validated] | libsamplerate (C FFI), custom (too much work) |
+| **TUI Framework** | ratatui + crossterm | ratatui is the successor to tui-rs, actively maintained, rich widget set. crossterm is cross-platform terminal backend. [Validated] | cursive (different paradigm, less flexible layout), tui-rs (unmaintained) |
+| **CLI Parsing** | clap v4 (derive) | Most popular Rust CLI framework. Derive macros reduce boilerplate. Built-in completions and man page generation. [Validated] | argh (minimal, fewer features), structopt (merged into clap v4) |
+| **Configuration** | toml + serde | TOML is human-readable, Rust ecosystem standard for config. serde makes (de)serialization trivial. [Validated] | figment (layered config — adds complexity without clear benefit for MVP), config-rs (less maintained) |
+| **Async Runtime** | tokio | Industry standard. Required by reqwest, needed for network I/O, IPC server. [Validated] | async-std (smaller community), smol (minimal — less ecosystem support) |
+| **HTTP Client** | reqwest | Built on tokio/hyper, supports streaming responses (essential for radio/podcast), cookies, redirects. [Validated] | ureq (blocking — doesn't support streaming well), hyper (too low-level) |
+| **IPC** | Unix domain socket + JSON-RPC 2.0 (via tokio) | Simple, no external deps, fast. Named pipes on Windows. JSON-RPC is human-debuggable. | D-Bus (Linux-only), gRPC (heavy for local IPC), MQTT (overkill) |
+| **Metadata/Tags** | lofty | Pure Rust, supports ID3v2, Vorbis, MP4, FLAC, APE tags. Read and write. Actively maintained. [Validated] | id3 (MP3 only), symphonia metadata (read-only, no write) |
+| **RSS Parsing** | feed-rs | Supports RSS 2.0, Atom, JSON Feed. Handles real-world feed quirks. [Validated] | rss crate (RSS only, no Atom), custom (feeds are messy — don't hand-roll) |
+| **Lyrics (LRC)** | Custom parser | LRC is trivial (~30 lines of Rust). No crate dependency justified. | lrc crate (if it exists — likely unmaintained) |
+| **Database** | SQLite via rusqlite (Phase 6+) | Proven, embedded, zero-config, supports FTS5. Perfect for library index. [Validated] | sled (Rust-native but less mature, no FTS), redb (too simple for library queries) |
+| **Full-text Search** | SQLite FTS5 | Comes free with rusqlite. No additional dependency. Sufficient for music library search. | tantivy (overkill for this use case, adds large dependency) |
+| **Plugin Runtime** | Lua via mlua (Phase 8) | See Section 7.1. Lightweight, proven, good sandboxing story. | WASM/wasmtime (future secondary), Rhai (too niche) |
+| **FFI (mobile)** | UniFFI (Phase 10) | Auto-generates Swift/Kotlin bindings from Rust. Mozilla-maintained. [Validation Required] | cbindgen (manual, more maintenance), cxx (C++ focused) |
+| **WASM Bindings** | wasm-bindgen + wasm-pack (Phase 9) | Standard Rust→WASM toolchain. [Validated] | stdweb (unmaintained) |
+| **Web Frontend** | Leptos (Phase 9) | Rust-native WASM framework. Keeps entire stack in Rust. Fine-grained reactivity, small bundle. | Svelte (good alternative if JS is preferred), React (heavy), Solid (smaller community) |
+| **Desktop Wrapper** | Tauri v2 (Phase 9) | Rust-native, lighter than Electron, native system tray, built-in updater. [Validated] | Electron (heavy, memory-hungry), native per-platform (too expensive for solo dev) |
+| **CI/CD** | GitHub Actions | Free for open source, excellent Rust support, matrix builds for cross-platform. [Validated] | GitLab CI (less community visibility) |
+| **Distribution** | cargo-dist (GitHub Releases) + Homebrew (Phase 5) + AUR (Phase 5) | cargo-dist auto-generates release binaries for all platforms. Homebrew/AUR added when user base grows. | Manual releases (error-prone), Nix (niche, add later via community) |
+| **Logging** | tracing | Structured, async-aware, span-based logging. Industry standard in Rust. [Validated] | log + env_logger (less structured, no spans) |
+| **Error Handling** | thiserror (library errors) + anyhow (application errors) | thiserror for typed errors in core/playback crates. anyhow for CLI binary where error context matters more than types. [Validated] | eyre (similar to anyhow, less popular), miette (fancy diagnostics — overkill for audio player) |
+| **Testing** | Built-in #[test] + proptest (property-based) | Standard Rust testing. proptest for DSP correctness (e.g., "EQ at 0dB gain = passthrough"). | quickcheck (less ergonomic than proptest) |
+
+**MSRV Policy**: Track stable Rust minus 2 releases (e.g., if current stable is 1.82, MSRV is 1.80). This balances access to new features with distro packager needs.
+
+**Dependency Policy**: Minimize dependencies. Every new crate must justify its inclusion. Prefer pure Rust crates over C FFI. Audit `cargo tree` regularly. Use `cargo deny` for license and advisory checking in CI.
+
+**Build Time**: Use `cargo-nextest` for parallel test execution. CI caches `target/` and `~/.cargo/registry`. Workspace incremental compilation. Consider `sccache` if CI times exceed 10 minutes.
+
+### 9.1 — Proof-of-Concept Gates
+
+**Gate 1: CPAL Audio Output (Before Phase 0 completion)**
+- [ ] Linux: CPAL plays decoded MP3 samples through ALSA and PipeWire
+- [ ] macOS: CPAL plays decoded MP3 samples through CoreAudio
+- [ ] Windows: CPAL plays decoded MP3 samples through WASAPI
+- [ ] Device enumeration: list available output devices
+- [ ] Suspend/resume: laptop sleep → wake → audio resumes without crash
+- [ ] Underrun: artificially delay decode thread → verify silence (not crash)
+- **Fallback if CPAL fails**: Platform-specific backends (much more work — escalates project risk significantly). Likelihood of failure: Low. [Validated] — CPAL is widely used.
+
+**Gate 2: WASM Audio (Before Phase 9 commitment)**
+- [ ] Decode MP3 entirely in WASM (symphonia compiled to wasm32)
+- [ ] AudioWorklet plays decoded samples with acceptable latency (<100ms)
+- [ ] Fetch and decode a remote audio URL (CORS permitting)
+- [ ] Local file playback via File API
+- **Fallback if WASM fails**: Web frontend as remote control only (no in-browser decoding). The web UI controls a running CLI instance via WebSocket.
+
+**Gate 3: UniFFI for Apple Platforms (Before Phase 10 commitment)**
+- [ ] Minimal Rust library callable from Swift on macOS via UniFFI
+- [ ] Async events (track change, position update) delivered from Rust to Swift callback
+- [ ] Static library packaging for iOS (no dynamic linking)
+- [ ] watchOS: basic feasibility test (can Rust code run on watchOS at all?)
+- **Fallback if UniFFI fails**: Manual cbindgen with C-compatible API surface. More boilerplate, but proven approach.
+
+---
+
+## SECTION 9A: AUDIO CORRECTNESS & RELIABILITY TESTING
+
+### 9A.1 — Decoder Tests
+
+- **Golden file tests**: Maintain a set of reference audio files (one per format) with known decoded sample checksums. Decode and compare. Run in CI.
+- **Format coverage**: MP3 (CBR, VBR), FLAC (16-bit, 24-bit), OGG Vorbis (multiple quality settings), Opus, WAV (PCM 16/24/32, float 32).
+- **Edge cases**: Files <1 second, files >2 hours, variable bitrate MP3, files with corrupted headers (should error gracefully, not panic), truncated files, zero-length files, files with extensive metadata (large embedded album art).
+- **Metadata accuracy**: Compare extracted metadata against known values for reference files.
+
+### 9A.2 — DSP & Pipeline Tests
+
+- **EQ passthrough**: All bands at 0dB → output equals input (within floating-point tolerance). Use `proptest` for this.
+- **EQ frequency response**: Boost band at 1kHz by +6dB → measure output energy at 1kHz vs other frequencies using FFT. Verify boost is within ±1dB of target.
+- **Volume accuracy**: Set gain to -6dB → output samples are 0.5× input (within tolerance).
+- **Resampler quality**: Resample 44.1kHz→48kHz→44.1kHz → compare to original. SNR should be >90dB.
+- **Seek accuracy**: Seek to 60.0s → next decoded sample should be within ±50ms of target.
+- **Gapless test (Phase 3)**: Generate two synthetic tracks (sine waves at different frequencies). Play back-to-back. Record output. Verify no silence gap >1ms and no click artifact at the transition.
+- **Speed change test (Phase 3)**: Play at 2.0x → verify output duration is ~50% of original.
+
+### 9A.3 — Playback Reliability Tests
+
+- **Network fault injection**: Simulate disconnects, redirects (301/302), slow streams (1 byte/sec), invalid ICY metadata, HTTPS cert errors. Verify graceful recovery or clear error messages.
+- **Underrun simulation**: Artificially throttle the decode thread (sleep between buffer fills). Verify silence output (not crash/noise) and recovery when throttle is removed.
+- **Format switching**: Play MP3 → FLAC → OGG → Opus in sequence without restarting. Verify seamless transitions (correct sample rate conversion between formats).
+- **Large playlist**: Load 10k+ track queue. Verify memory stays bounded (<100MB), UI remains responsive, next/prev and shuffle work correctly.
+- **24-hour stability test**: Play internet radio for 24+ hours. Monitor for memory leaks (RSS should be stable ±10%), file descriptor leaks, CPU creep.
+
+### 9A.4 — CI & Platform Testing
+
+- **Mock audio backend**: Implement `AudioOutput` trait with a `MockOutput` that writes samples to a buffer/file instead of a real device. All pipeline tests use this — no real audio hardware needed in CI. 🟢
+- **Platform matrix**: GitHub Actions runners: Ubuntu (ALSA headers installed), macOS, Windows. Compile and run tests on all three.
+- **Performance budgets** (validate after Phase 1, enforce from Phase 2):
+  - Startup time: <500ms to first UI render (no audio playing)
+  - Memory: <50MB RSS while playing a local FLAC file
+  - CPU: <5% during steady-state MP3 playback on a modern machine
+  - (Adjust thresholds based on actual measurement — these are initial targets)
+
+### 9A.5 — TUI Responsiveness Tests
+
+- **Input latency**: Measure time from keypress event to visual update. Target: <50ms.
+- **Terminal resize**: Resize terminal during playback. UI must re-layout without crash or visual corruption. Test with `resize` events in crossterm.
+- **Visualizer frame rate**: Measure actual FPS under load. Target: 20+ FPS during playback. If TUI thread falls behind, skip frames — never block audio.
+
+---
+---
+## SECTION 10: DATA MODEL
+
+### Entity Relationships
+
+```
+UserConfig (1) ---- (N) ProviderConfig
+     |
+     +---- (1) Session ---- (1) Queue ---- (N) Track
+                                              |
+Track ---- (0..1) TrackMetadata               |
+                                              |
+Playlist (N) ---- (N) Track ------------------+
+
+RadioStation (standalone, favoritable)
+PodcastFeed (1) ---- (N) PodcastEpisode
+Favorite ---- Track | RadioStation | PodcastEpisode
+ListeningHistory (N) ---- Track
+EQPreset (standalone, referenced by Session)
+Theme (standalone, referenced by Session)
+```
+
+### Storage Strategy
+
+| Entity | Storage | Format | Syncs? |
+|--------|---------|--------|--------|
+| UserConfig | `config.toml` | TOML | Yes |
+| Session | `session.toml` | TOML | Yes |
+| Playlists | `playlists/<name>.toml` | TOML | Yes |
+| EQPreset (custom) | In `config.toml` | TOML | Yes |
+| Theme (custom) | `themes/<name>.toml` | TOML | Yes |
+| RadioStations (custom) | `stations.toml` | TOML | Yes |
+| PodcastFeeds + EpisodeState | `podcasts.toml` | TOML | Yes |
+| Favorites | `favorites.toml` | TOML | Yes |
+| ListeningHistory | `history.toml` -> SQLite (Phase 6) | TOML->SQLite | Yes |
+| TrackMetadata (cache) | In-memory HashMap | Memory | No |
+| Library Index (Phase 6) | `library.db` | SQLite | No (local cache) |
+| Credentials | OS keychain | Platform-specific | No |
+
+### Migration Strategy
+- Phase 0-5: TOML files only. Schema changes = add fields with defaults (backward compatible).
+- Phase 6: Introduce SQLite for library + history. TOML remains for config/session/playlists.
+- Cross-platform sync: TOML files use relative paths (`~/Music/...`), no platform-specific separators.
+- Track identity: content hash (for local) or provider-specific ID (for streaming) — not file path.
+
+---
+
+## SECTION 11: DESIGN BRIEF
+
+### 11.1 -- TUI Design Principles
+
+1. **Keyboard-Native**: Every action accessible via keyboard. Mouse optional.
+2. **Information-Dense, Uncluttered**: Track info, progress, playlist, and controls on one screen.
+3. **Responsive**: Graceful degradation from 200x60 down to 80x24. Panels collapse at breakpoints.
+4. **Beautiful by Default**: Attractive default theme. First impression matters.
+5. **Vim-like Navigation**: j/k, g/G, Ctrl+D/U everywhere lists appear.
+6. **Discoverable**: ? or Ctrl+K shows all keybindings. Status bar hints for common actions.
+
+### 11.2 -- Main TUI Layout
+
+```
++-- Track Info -------------------------------------------------+
+| Artist -- Title                              Album            |
+| > ================================= 2:22 / 5:04              |
+| Vol: -3dB  EQ: Rock  Shuffle: Off  Repeat: Off               |
++-- Playlist ----------------------+-- Visualizer --------------+
+| > 1. Currently Playing           |  ##                        |
+|   2. Next Track                  |  ## ##                     |
+|   3. Another Track               |  ## ## ## ##               |
+|   4. ...                         |  ## ## ## ## ##            |
++----------------------------------+----------------------------+
+| Spc:Play/Pause  n/p:Next/Prev  Up/Dn:Select  ?:Help          |
++---------------------------------------------------------------+
+```
+
+At small terminals (< 100 cols): hide visualizer panel.
+At very small (80x24): collapse to track info + playlist only.
+`--compact` flag: cap width at 80 columns.
+
+### 11.3 -- Default Keybinding Table
+
+| Key | Action | Category |
+|-----|--------|----------|
+| Space | Play / Pause | Transport |
+| s | Stop | Transport |
+| n / p | Next / Previous | Transport |
+| <- / -> | Seek +/-5s | Transport |
+| Shift+<- / -> | Seek +/-30s | Transport |
+| + / - | Volume +/-1dB | Transport |
+| ] / [ | Speed +/-0.25x | Transport |
+| j / k | Scroll down / up | Navigation |
+| g / G | Top / Bottom of list | Navigation |
+| Ctrl+D / Ctrl+U | Half-page down / up | Navigation |
+| Enter | Play selected track | Navigation |
+| / | Search/filter playlist | Navigation |
+| Tab | Focus next panel | Navigation |
+| f | Toggle favorite | Action |
+| o | Open file browser | Action |
+| u | Load URL | Action |
+| e | Cycle EQ preset | Audio |
+| t | Cycle theme | UI |
+| v | Cycle visualizer mode | UI |
+| V | Full-screen visualizer | UI |
+| r | Cycle repeat (off/all/one) | Playback |
+| z | Toggle shuffle | Playback |
+| m | Toggle mono downmix | Audio |
+| ? / Ctrl+K | Show all keybindings | Help |
+| q | Quit (auto-saves session) | System |
+
+### 11.4 -- Future Platform UI Approach
+
+- **Web**: Responsive SPA, dark mode default, Media Session API for browser media keys.
+- **macOS App**: Sidebar + content layout, menu bar mini-player, global hotkeys.
+- **iOS**: Tab-based nav (Now Playing, Library, Radio, Podcasts), Lock Screen widget, CarPlay.
+- **Apple Watch**: Now Playing complication, basic transport controls glance.
+
+---
+
+## SECTION 12: COMPETITIVE ANALYSIS
+
+### 12.1 -- Terminal Audio Players
+
+| Player | Language | Key Features | Platforms | Strengths | Weaknesses |
+|--------|---------|-------------|-----------|-----------|------------|
+| **cliamp** | Go | Full-featured, 10+ providers, EQ, viz, plugins, themes | Linux, macOS | Most complete TUI player | No mobile/web, single-platform architecture |
+| **ncmpcpp** | C++ | MPD client, tag editor, visualizer | Linux, macOS | Mature, MPD ecosystem | Requires MPD, dated UI |
+| **cmus** | C | Lightweight, fast, Vi-like | Linux, macOS, *BSD | Very fast, minimal | No streaming, minimal features |
+| **musikcube** | C++ | Library management, streaming server | Linux, macOS, Win | Library + server | Complex setup |
+| **termusic** | Rust | TUI player, podcast support | Linux, macOS | Rust, some features | Smaller feature set |
+| **mpv** | C | Universal media player | All | Plays everything | Not music-focused, no TUI |
+
+### 12.2 -- Differentiation
+
+This project's unique position:
+1. **Pure Rust audio pipeline** -- no C dependencies for core codecs
+2. **TUI-first with rich visuals** -- EQ, visualizer, themes, lyrics
+3. **Multi-source** -- local + radio + podcasts in one player
+4. **Layered architecture** -- designed for WASM/mobile expansion `[Validation Required]`
+5. **Open source, zero telemetry** -- counter-position to Spotify/Apple Music
+
+---
+
+## SECTION 13: LICENSING & OPEN SOURCE STRATEGY
+
+### License: Dual MIT + Apache 2.0
+
+Rust ecosystem standard. Maximum contribution friendliness. Apache 2.0 patent grant. No copyleft friction. Compatible with all major Rust crate licenses.
+
+**Rejected**: GPL v3 (copyleft friction), AGPL (too restrictive for library crate), MIT-only (no patent grant).
+
+### Contribution Model
+
+- **DCO** (Developer Certificate of Origin) -- `Signed-off-by` trailer, simpler than CLA
+- CONTRIBUTING.md: build instructions, architecture overview, coding conventions, PR process
+- Issue templates: Bug Report, Feature Request, Provider Request
+- "Good first issue" label for onboarding new contributors
+
+### Monetization
+
+**Primary**: GitHub Sponsors. Integrated, simple, no tier complexity initially.
+**Secondary**: Ko-fi for casual one-time donations.
+
+---
+
+## SECTION 14: PHASED ROADMAP WITH MILESTONES
+
+### Phase 0: First Sound
+**Goal**: `kora song.mp3` produces audio on Linux, macOS, and Windows.
+**Deliverables**: Cargo project, module structure, symphonia -> rtrb -> CPAL pipeline, basic CLI, CI.
+**Acceptance**: Audio plays correctly on all 3 platforms. CI green.
+**Cut line**: Windows can slip to Phase 1 if WASAPI issues arise.
+
+### Phase 1: Minimum Playable Player (MVP)
+**Goal**: A TUI player the developer uses daily for local file playback.
+**Deliverables**: ratatui TUI (track info, progress, controls), queue from CLI args, keyboard controls, one theme, session persistence, config.toml.
+**Acceptance**: Developer uses it instead of mpv/cmus for 1 week. Quit -> restart -> resume works.
+**Cut line**: Config can be minimal (volume + theme only).
+
+### Phase 2: Daily Driver (Beta)
+**Goal**: Local + radio + basic podcast. Multiple themes.
+**Deliverables**: HTTP stream playback, Radio Browser integration + custom stations, basic podcast RSS, file browser, 10+ themes, shuffle/repeat, sleep timer, favorites.
+**Acceptance**: Play a radio station with ICY metadata. Play a podcast episode. Resume position.
+**Cut line**: Podcast downloads defer to Phase 4.
+
+### Phase 3: Audio Polish
+**Goal**: The player sounds great.
+**Deliverables**: 10-band graphic EQ, spectrum visualizer (bars), gapless playback, speed control, AAC/ALAC, synced lyrics, ReplayGain, audio device selection.
+**Acceptance**: EQ audibly changes sound. Gapless album playback. Visualizer syncs with audio.
+**Cut line**: Lyrics and ReplayGain can defer.
+
+### Phase 4: Podcast Client
+**Goal**: Full podcast experience.
+**Deliverables**: OPML, subscriptions, episode tracking, downloads, chapters, per-feed speed.
+**Acceptance**: Import OPML, subscribe, auto-refresh, download episodes, track played state.
+
+### Phase 5: Power User & Ecosystem
+**Goal**: Scriptable, system-integrated.
+**Deliverables**: IPC remote control, MPRIS/media keys (souvlaki), CLI flags, shell completions, headless/daemon mode, man page.
+**Acceptance**: `kora pause` controls a running instance. Media keys work on all platforms.
+
+### Phase 6: Library & Social (1.0 Release)
+**Goal**: Library management. This is the 1.0 milestone.
+**Deliverables**: SQLite library index, library browser, statistics, Last.fm/ListenBrainz scrobbling (opt-in), smart playlists, comprehensive docs, Homebrew/AUR/cargo-dist packaging.
+**Acceptance**: Index 10k+ files in <30s. Browse by artist/album/genre. Scrobble to Last.fm.
+
+### Phase 7: Streaming Providers (Post-1.0)
+Open providers first: Navidrome (Subsonic), Jellyfin, Plex `[V.R.]`. OS keychain credentials.
+Spotify/YouTube: **Research only** -- pursue only after ToS validation.
+
+### Phase 8: Plugin System (Post-1.0)
+Lua runtime (mlua), plugin API, manager CLI. Only after core APIs stabilize.
+
+### Phase 9: Cross-Platform Expansion (Research)
+Each requires a proof-of-concept gate (Section 9.1): WASM engine, web frontend, Tauri desktop, macOS/iOS FFI.
+
+### Phase 10: Native Mobile & Sync (Moonshot)
+iOS app, Apple Watch, self-hosted sync server (axum + SQLite), cross-device state sync.
+
+---
+
+## SECTION 15: FIRST 90 DAYS -- EXECUTION PLAN
+
+### 15.1 -- Technical Spikes (Weeks 1-2)
+
+| # | Spike | Success Criteria | Effort |
+|---|-------|-----------------|--------|
+| 1 | symphonia decode MP3/FLAC/OGG -> f32 | Correct output, <1ms/frame | S |
+| 2 | CPAL output on Linux (ALSA + PipeWire), macOS, Windows | Audio plays on all three | M |
+| 3 | rtrb ring buffer: decode thread -> audio callback | No underruns at 100ms buffer | S |
+| 4 | ratatui: render progress bar + respond to keypress | <50ms input latency | S |
+| 5 | TOML session: serialize/deserialize playback state | Round-trip preserves all fields | S |
+| 6 | HTTP stream: reqwest -> decode -> play | Radio URL plays with ICY metadata | M |
+
+Defer from first 90 days: IPC, plugins, provider abstraction, WASM/FFI, full podcast client.
+
+### 15.2 -- First 10 Epics
+
+| # | Epic | Effort | Dependencies | Complexity |
+|---|------|--------|-------------|------------|
+| 1 | Audio pipeline (decode -> ring buffer -> CPAL) | M | Spikes 1-3 | Y |
+| 2 | Basic CLI (`kora file.mp3` plays) | S | Epic 1 | G |
+| 3 | Multi-file queue (play *.mp3, next/prev) | M | Epic 2 | G |
+| 4 | TUI shell (track info, progress bar, controls) | M | Epic 3, Spike 4 | Y |
+| 5 | Seek & volume controls | S | Epic 4 | G |
+| 6 | Session persistence (quit -> resume) | S | Epic 5, Spike 5 | G |
+| 7 | Config file (config.toml, basic settings) | S | Epic 6 | G |
+| 8 | Theme support (one default theme) | S | Epic 4 | G |
+| 9 | CI pipeline (GitHub Actions, 3 platforms) | M | Epic 1 | G |
+| 10 | First release (v0.1.0 on GitHub Releases) | S | Epic 9 | G |
+
+### 15.3 -- Due Diligence Backlog
+
+- [ ] Radio Browser API: test rate limits, mirror availability, response format
+- [ ] LRCLIB lyrics API: verify availability, terms, response format
+- [ ] souvlaki crate: verify MPRIS + macOS + Windows support quality
+- [ ] keyring crate: test on Linux (libsecret), macOS, Windows
+- [ ] symphonia AAC decoder: quality and completeness
+- [ ] Pitch-preserving time-stretch: evaluate Rust crates or C bindings
+- [ ] Spotify Developer ToS: open-source player feasibility
+- [ ] yt-dlp legal status: community consensus
+
+### 15.4 -- Architecture Decision Records (ADRs)
+
+1. **ADR-001**: Audio pipeline threading model (decode -> ring buffer -> callback)
+2. **ADR-002**: Single crate with module boundaries vs multi-crate workspace
+3. **ADR-003**: Provider trait design (capability-based, evolvable)
+4. **ADR-004**: Session persistence format (TOML, not SQLite)
+5. **ADR-005**: Ring buffer implementation choice (rtrb)
+
+---
+
+## SECTION 16: DEPENDENCY MAP
+
+```
+Phase 0 --> Phase 1 --> Phase 2 --+-- Phase 3 --> Phase 5 --> Phase 6 (1.0)
+                                   |
+                                   +-- Phase 4 ----------------+
+                                                                |
+(Parallelizable: CI, docs, themes, config design)               |
+                                                                v
+Post-1.0: Phase 7 (providers), Phase 8 (plugins) -- independent of each other
+
+Research: Phase 9 (requires PoC gates) --> Phase 10 (requires Phase 9 success)
+```
+
+**Critical path**: Phase 0 -> Phase 1. The audio pipeline is the single critical dependency. Everything downstream requires reliable decode -> output. If this takes longer than expected, all phases shift.
+
+**Parallelizable with Phase 0**: Theme design, config format, documentation, CI setup, Radio Browser API investigation, competitive analysis.
+
+---
+
+## SECTION 17: FEASIBILITY & COMPROMISE MATRIX
+
+| Challenge | Ideal Solution | Compromise | Impact of Compromise | Recommendation |
+|-----------|---------------|-----------|---------------------|----------------|
+| Gapless playback | Pre-decode next track, seamless buffer swap | 50ms crossfade between tracks | Audiophiles notice | Start with crossfade; implement true gapless in Phase 3 |
+| Cross-platform audio | CPAL everywhere | Platform-specific fallbacks for edge cases | More code, more testing | CPAL first; add fallbacks only if bugs found |
+| Pitch-preserving speed | WSOLA/phase vocoder | Accept pitch change with speed | Podcasters want pitch preservation | Pitch shift for MVP; investigate time-stretch for Phase 4 |
+| WASM audio | Full engine in WASM + AudioWorklet | Separate lightweight web player | Code duplication | Defer until PoC validates feasibility |
+| Spotify integration | Official API + raw audio | Skip entirely for 1.0 | Can't play Spotify in our player | **Skip.** Focus on open providers. |
+| Lyrics | Real-time synced from multiple sources | LRC sidecar files + embedded only | No lyrics for streaming content | LRC + embedded first; external API later |
+| Visualizer performance | 60fps dedicated render thread | 20fps on TUI thread, drop frames | Less smooth | 20fps on TUI thread; optimize later if needed |
+| Plugin sandboxing | WASM isolation | Lua sandbox (restrict stdlib) | Less isolation than WASM | Lua sandbox with restricted stdlib; require permission manifest |
+
+---
+
+## SECTION 18: NAMING & BRANDING (OPTIONAL)
+
+**Top candidates** (all `[Validation Required]` -- check crates.io, GitHub, domains):
+
+| Name | Strengths | Weaknesses |
+|------|-----------|------------|
+| **kora** | Short (4 chars), musical (West African string instrument), distinctive, easy to type | May conflict with existing projects |
+| **cadence** | Musical term (rhythm), elegant, 7 chars | May conflict with Linux Cadence audio tool |
+| **riff** | Musical (guitar riff), short (4 chars), punchy | Very common word, likely conflicts |
+| **forte** | Musical (loud), short (5 chars), strong feel | May conflict |
+| **resonance** | Descriptive, audio-themed, professional | Long to type (9 chars) |
+| **wavelet** | Audio/DSP reference, technical, short-ish | Niche/academic feel |
+| **rustamp** | Clear Rust + Winamp heritage | A bit literal |
+| **oxide** | Rust-themed (iron oxide), short | Overused in Rust ecosystem |
+
+**Recommendation**: **kora** -- Short, distinctive, musical, easy to type, unlikely to conflict.
+`kora play ~/Music/`, `kora status --json`, `kora --theme Nord`.
+
+**Runner-ups**: **cadence** (if no Linux conflict), **riff** (if crate available).
+
+---
+
+## SECTION 19: FAILURE MODE ANALYSIS
+
+| # | Failure Mode | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | Audio pipeline complexity delays MVP | Medium | High (blocks everything) | Phase 0 dedicated to proving pipeline. Technical spikes before TUI work. |
+| 2 | CPAL platform inconsistencies | Medium | Medium | Test all platforms in Phase 0. rodio as higher-level fallback. Accept platform workarounds. |
+| 3 | Feature creep | High | High (burnout, never ships) | 3-5 deliverables per phase. Release tier definitions. "Daily use" as MVP criterion. |
+| 4 | Streaming provider APIs restrictive | High (Spotify/YT) | Low (for 1.0) | 1.0 excludes restricted providers. Open providers (radio, podcast, Subsonic) are sufficient. |
+| 5 | WASM/web target impractical | Medium | Low (moonshot) | PoC gate required. Failure = web is separate app. |
+| 6 | Rust -> Swift FFI too complex | Medium | Low (moonshot) | PoC gate required. Failure = no mobile app. |
+| 7 | **Solo developer burnout** | **High** | **Critical** | Open-ended timeline. Ship usable increments. Daily use as motivation. Accept contributions. **The project succeeds if Phase 1 ships -- everything after is bonus.** |
+
+---
+
+## SECTION 20: OPEN QUESTIONS & DECISION LOG
+
+| # | Decision | Recommendation | Status |
+|---|----------|----------------|--------|
+| 1 | Audio backend | CPAL | Decided |
+| 2 | Workspace structure | Single crate with clear modules; split when needed | Decided |
+| 3 | Plugin runtime | Lua (mlua), post-1.0 | Decided |
+| 4 | Podcast scope (beta) | Simple RSS playback | Decided |
+| 5 | Radio directory | Radio Browser API + user TOML | Decided |
+| 6 | Session persistence | TOML files | Decided |
+| 7 | Sync strategy | File-based via cloud drives; sync server post-1.0 | Decided |
+| 8 | License | Dual MIT + Apache 2.0 | Decided |
+| 9 | Web frontend framework | Leptos (Rust WASM) or Svelte | Open -- defer to Phase 9 |
+| 10 | FFI for Apple platforms | UniFFI | Open -- defer to Phase 9 |
+| 11 | Visualizer thread model | TUI thread at 20fps | Decided |
+| 12 | Project name | **kora** (recommended) | Open -- validate availability |
+| 13 | Pitch-preserving speed | Defer; accept pitch shift for MVP | Decided |
+| 14 | Spotify viability | Skip for 1.0; Research only | Decided |
+| 15 | Stream recording | Red line -- will not implement | Decided |
+
+---
+
+*This roadmap is a living document. Revisit decisions as the project evolves. The most important thing is Phase 0: get sound out of the speakers. Everything else follows.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.x     | :white_check_mark: |
+
+Only the latest release is supported with security updates.
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+If you discover a security vulnerability in kora, please report it through GitHub's private vulnerability reporting feature:
+
+1. Go to the [Security tab](https://github.com/kafkade/kora/security) of this repository
+2. Click **"Report a vulnerability"**
+3. Fill out the form with details about the vulnerability
+
+### What to expect
+
+- **Acknowledgment**: We will acknowledge your report within **48 hours**
+- **Assessment**: We will assess the severity and impact within **7 days**
+- **Resolution**: We aim to release a fix within **90 days** of the initial report, depending on complexity
+- **Disclosure**: We will coordinate disclosure timing with you
+
+### What to include
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Any suggested fixes (if you have them)
+
+### Scope
+
+Security issues in kora may include:
+
+- Credential storage vulnerabilities (OAuth tokens, API keys)
+- Path traversal in file browser or local provider
+- Memory safety issues in the audio pipeline
+- Malicious audio file processing (buffer overflow, denial of service)
+- Plugin sandbox escapes (when the plugin system is implemented)
+
+## Thank You
+
+We appreciate responsible disclosure and will credit reporters (with their permission) in our release notes and changelog.

--- a/docs/adr/001-audio-pipeline-threading.md
+++ b/docs/adr/001-audio-pipeline-threading.md
@@ -1,0 +1,54 @@
+# ADR-001: Audio Pipeline Threading Model
+
+## Status
+
+Accepted
+
+## Context
+
+kora's audio pipeline must decode audio from various sources (files, HTTP streams) and
+output it through the system audio device with zero audible glitches. The primary
+constraint is that the audio output callback (CPAL) runs on a real-time thread where
+blocking, allocation, and I/O are forbidden.
+
+We need to decide how threads communicate and what guarantees each thread provides.
+
+## Decision
+
+Three-thread architecture with a lock-free SPSC ring buffer:
+
+```
+[Decode Thread] --→ rtrb Ring Buffer --→ [Audio Callback Thread]
+       ↑                                          ↓
+  (can block,                              (REAL-TIME:
+   allocate,                                no alloc,
+   do I/O)                                  no locks,
+                                            no I/O)
+```
+
+A separate main/TUI thread handles user input and rendering.
+
+**Real-time rules for the audio callback thread** (non-negotiable):
+
+1. No heap allocation (`Vec::push`, `String::new`, `Box::new`, `format!`)
+2. No blocking I/O (file, network, stdout)
+3. No mutex waits — lock-free only
+4. No channel blocking — `try_recv()` / `try_send()` only
+5. No logging — atomic flag checks only
+6. Underrun: output silence (zeros), set atomic flag
+
+**Communication**:
+- Decode → Audio: `rtrb` lock-free SPSC ring buffer (~200ms of audio)
+- Audio → Main: atomic flags (underrun, playback position)
+- Main → Decode: `std::sync::mpsc` or tokio channel (seek, stop, next)
+
+## Consequences
+
+- The decode thread can safely allocate, parse metadata, and do network I/O without
+  affecting audio playback
+- The audio callback is simple: pop from ring buffer, apply DSP, output
+- Seeking requires flushing the ring buffer (brief silence is acceptable)
+- Gapless playback requires the decode thread to pre-fill the buffer with the next
+  track's samples before the current track ends
+- This model maps cleanly to all target platforms (native CPAL, Web AudioWorklet,
+  AVAudioEngine) — only the audio output adapter changes

--- a/docs/adr/002-single-crate-structure.md
+++ b/docs/adr/002-single-crate-structure.md
@@ -1,0 +1,45 @@
+# ADR-002: Single Crate with Module Boundaries
+
+## Status
+
+Accepted
+
+## Context
+
+kora's architecture defines four layers: domain core, playback core, audio backend
+adapters, and frontend adapters. We need to decide whether to implement these as
+separate Cargo workspace crates from day one or as modules within a single crate.
+
+## Decision
+
+Start as a **single crate** with clear module boundaries:
+
+```
+src/
+├── core/       — Domain models, traits, config (no audio deps)
+├── playback/   — Decode, DSP, state machine (symphonia, rtrb)
+├── backend/    — Audio output adapters (CPAL)
+├── providers/  — Audio source implementations
+├── tui/        — Terminal UI (ratatui)
+└── ipc/        — Remote control protocol
+```
+
+**Split into a Cargo workspace when**:
+- A second frontend needs the core (Phase 7+ web/mobile)
+- Compile times exceed 60 seconds incremental
+- A module's dependencies block cross-compilation (e.g., CPAL blocking WASM)
+
+## Alternatives Considered
+
+- **Multi-crate workspace from day one**: Rejected — premature separation adds friction
+  for a solo developer (more Cargo.toml files, cross-crate dependency management,
+  slower iteration). The module boundaries preserve the option to split later.
+
+## Consequences
+
+- Faster iteration during early development
+- `cargo build` builds everything in one pass
+- Module boundaries are enforced by convention, not by the compiler — requires
+  discipline (e.g., `tui/` must not import from `playback/` internals directly)
+- When splitting occurs, it should be mechanical: move `src/core/` to `crates/core/`,
+  update imports, add workspace Cargo.toml

--- a/docs/adr/003-provider-trait-design.md
+++ b/docs/adr/003-provider-trait-design.md
@@ -1,0 +1,57 @@
+# ADR-003: Provider Trait Design
+
+## Status
+
+Accepted
+
+## Context
+
+kora supports multiple audio sources (local files, internet radio, podcasts, and future
+streaming services). We need a common abstraction so the playback engine doesn't need to
+know the specifics of each source.
+
+## Decision
+
+Use **capability-based trait composition** with an evolvable internal API:
+
+```rust
+pub trait Provider: Send + Sync {
+    fn name(&self) -> &str;
+    fn capabilities(&self) -> Capabilities;
+}
+
+pub trait Browsable: Provider {
+    async fn browse(&self, path: &str) -> Result<Vec<BrowseItem>>;
+}
+
+pub trait Searchable: Provider {
+    async fn search(&self, query: &str, limit: usize) -> Result<Vec<Track>>;
+}
+
+pub trait Streamable: Provider {
+    async fn resolve(&self, track: &Track) -> Result<AudioSource>;
+}
+```
+
+**Key decisions**:
+- Each provider implements only the traits it supports (local files: Browsable +
+  Streamable; radio: Browsable + Searchable + Streamable)
+- The API is **internal and evolvable** — do NOT stabilize as a public plugin API until
+  at least 3 providers are implemented and common patterns emerge
+- All async methods support cancellation via `tokio::select!` or `CancellationToken`
+- Errors use a `ProviderError` enum with variants: `NetworkError`, `AuthError`,
+  `NotFound`, `RateLimited`, `Timeout`, `Unavailable`
+
+## Alternatives Considered
+
+- **Single monolithic Provider trait**: Rejected — forces providers to stub out methods
+  they don't support (e.g., local files implementing `authenticate()`)
+- **Stable public API from day one**: Rejected — premature. We don't know the right
+  abstraction until we've built local, radio, and podcast providers.
+
+## Consequences
+
+- Adding a new provider only requires implementing the relevant subset of traits
+- The playback engine queries capabilities at runtime to decide what UI to show
+- The trait API will likely change as we learn from implementing providers — this is
+  expected and acceptable until 1.0

--- a/docs/adr/004-session-persistence-toml.md
+++ b/docs/adr/004-session-persistence-toml.md
@@ -1,0 +1,56 @@
+# ADR-004: Session Persistence via TOML
+
+## Status
+
+Accepted
+
+## Context
+
+kora needs to persist playback state (current track, position, queue, volume, EQ preset,
+theme, shuffle/repeat) so users can resume where they left off after quitting.
+
+Options: TOML file, JSON file, SQLite database, binary format.
+
+## Decision
+
+Use a **TOML file** (`~/.config/kora/session.toml`) for session persistence.
+
+Example:
+
+```toml
+[session]
+track = "~/Music/album/01-track.flac"
+position_ms = 142000
+volume_db = -3.0
+eq_preset = "Flat"
+theme = "Nord"
+shuffle = false
+repeat = "off"
+visualizer = "bars"
+
+[[queue]]
+path = "~/Music/album/01-track.flac"
+
+[[queue]]
+path = "~/Music/album/02-track.flac"
+```
+
+**Behavior**:
+- Auto-save on quit and every 30 seconds during playback
+- On startup: restore state, resume paused (user presses play to continue)
+- Crash recovery: the periodic auto-save provides a recent snapshot
+
+## Alternatives Considered
+
+- **SQLite**: Rejected for session state — overkill for a single document of settings.
+  SQLite is appropriate for the library index (Phase 6) but not for config/session.
+- **JSON**: Rejected — less human-readable than TOML, no comments support.
+- **Binary (bincode/MessagePack)**: Rejected — not human-editable, makes debugging harder.
+
+## Consequences
+
+- Users can manually edit session.toml to fix issues or set state
+- Session files are portable and syncable via cloud drives (iCloud, Google Drive, etc.)
+- TOML serialization/deserialization via `serde` + `toml` crate is trivial
+- File paths in session use `~/` prefix for cross-device portability
+- When library indexing arrives (Phase 6), SQLite handles that separately

--- a/docs/adr/005-ring-buffer-rtrb.md
+++ b/docs/adr/005-ring-buffer-rtrb.md
@@ -1,0 +1,43 @@
+# ADR-005: Ring Buffer Selection (rtrb)
+
+## Status
+
+Accepted
+
+## Context
+
+The audio pipeline needs a lock-free, single-producer single-consumer (SPSC) ring buffer
+to pass decoded audio samples from the decode thread to the CPAL audio callback thread.
+The callback thread is real-time — the buffer must be lock-free and allocation-free in
+steady state.
+
+## Decision
+
+Use **rtrb** (Real-Time Ring Buffer) as the SPSC ring buffer implementation.
+
+## Evaluation
+
+| Crate | Lock-free | SPSC | Allocation-free | Audio-focused | Maintained |
+|-------|-----------|------|-----------------|---------------|------------|
+| `rtrb` | ✅ | ✅ | ✅ (after init) | ✅ (designed for audio) | ✅ |
+| `ringbuf` | ✅ | ✅ | ✅ | ❌ (general purpose) | ✅ |
+| `crossbeam-queue` | ✅ | ❌ (MPMC) | ✅ | ❌ | ✅ |
+| `std::sync::mpsc` | ❌ (locks) | N/A | ❌ | ❌ | ✅ |
+
+## Key Properties
+
+- **Lock-free**: `push()` and `pop()` never block or acquire locks
+- **Bounded**: fixed capacity allocated at creation, no runtime allocation
+- **Wait-free for single producer/consumer**: exactly one thread pushes, one pops
+- **Cache-friendly**: contiguous memory layout, minimal false sharing
+- **`slots()` method**: producer can check available space without blocking
+
+## Consequences
+
+- The decode thread pushes samples via `producer.push()`, sleeping briefly if the buffer
+  is full (backpressure — this is safe since the decode thread is not real-time)
+- The audio callback pops samples via `consumer.pop()`, outputting silence on underrun
+- Buffer size (~200ms at 44.1kHz stereo ≈ 17,640 samples) provides enough runway to
+  absorb decode jitter without audible gaps
+- The `Consumer` must be moved into the CPAL callback closure — do NOT use `unsafe`
+  `ptr::read` tricks; Rust ownership handles this correctly

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for kora.
+
+ADRs document significant technical decisions made during the project's development.
+Each record captures the context, decision, and consequences so future contributors
+understand why things are built the way they are.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](001-audio-pipeline-threading.md) | Audio Pipeline Threading Model | Accepted |
+| [ADR-002](002-single-crate-structure.md) | Single Crate with Module Boundaries | Accepted |
+| [ADR-003](003-provider-trait-design.md) | Provider Trait Design | Accepted |
+| [ADR-004](004-session-persistence-toml.md) | Session Persistence via TOML | Accepted |
+| [ADR-005](005-ring-buffer-rtrb.md) | Ring Buffer Selection (rtrb) | Accepted |

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -8,12 +8,14 @@ use rtrb::RingBuffer;
 
 /// Information about an available audio output device.
 #[derive(Debug)]
+#[allow(dead_code)] // Used in tests and future device selection UI
 pub struct AudioDevice {
     pub name: String,
     pub is_default: bool,
 }
 
 /// List all available audio output devices.
+#[allow(dead_code)] // Used in tests and future device selection UI
 pub fn list_devices() -> Result<Vec<AudioDevice>> {
     let host = cpal::default_host();
     let default_name = host

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -93,9 +93,9 @@ pub fn play_audio(
             )
         })?;
 
-    stream.play().with_context(|| {
-        format!("Failed to start playback on '{device_name}'")
-    })?;
+    stream
+        .play()
+        .with_context(|| format!("Failed to start playback on '{device_name}'"))?;
 
     // Push samples into the ring buffer from the main thread.
     // Volume scaling happens here (producer side), not in the callback.

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{SampleRate, StreamConfig};
-use rtrb::{Consumer, RingBuffer};
+use rtrb::RingBuffer;
 
 /// Play pre-decoded f32 samples through CPAL.
 ///
@@ -33,34 +33,24 @@ pub fn play_audio(
 
     // Ring buffer: ~200ms of audio
     let buffer_frames = (sample_rate as usize * channels * 200) / 1000;
-    let (mut producer, consumer) = RingBuffer::new(buffer_frames);
+    let (mut producer, mut consumer) = RingBuffer::new(buffer_frames);
 
-    let _stop_playback = stop.clone();
-    let _playback_done = Arc::new(AtomicBool::new(false));
-
-    // Build the output stream — the callback is real-time safe:
-    // only reads from the lock-free ring buffer, no alloc/locks/I/O.
+    // Build the output stream. The consumer is moved into the callback
+    // and owned exclusively by it — no unsafe needed.
     let stream = device
         .build_output_stream(
             &config,
             move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                let mut consumer = unsafe {
-                    // SAFETY: we ensure only one callback runs at a time (CPAL guarantee)
-                    // and the consumer is only accessed from this callback.
-                    std::ptr::read(&consumer as *const Consumer<f32>)
-                };
+                // REAL-TIME SAFE: only pop from lock-free ring buffer
                 for sample in data.iter_mut() {
                     match consumer.pop() {
                         Ok(s) => *sample = s,
-                        Err(_) => {
-                            *sample = 0.0; // Underrun: output silence
-                        }
+                        Err(_) => *sample = 0.0, // Underrun: silence
                     }
                 }
-                std::mem::forget(consumer);
             },
             move |err| {
-                tracing::error!("Audio stream error: {err}");
+                eprintln!("Audio stream error: {err}");
             },
             None,
         )
@@ -69,7 +59,7 @@ pub fn play_audio(
     stream.play().context("Failed to start audio playback")?;
 
     // Push samples into the ring buffer from the main thread.
-    // Apply volume scaling here (before the real-time callback).
+    // Volume scaling happens here (producer side), not in the callback.
     let mut pos = 0;
     while pos < samples.len() && !stop.load(Ordering::Relaxed) {
         let slots = producer.slots();
@@ -78,18 +68,27 @@ pub fn play_audio(
             continue;
         }
         let chunk_end = (pos + slots).min(samples.len());
-        for &s in &samples[pos..chunk_end] {
+        let chunk = &samples[pos..chunk_end];
+        for &s in chunk {
+            // push won't fail here because we checked slots
             let _ = producer.push(s * volume);
         }
         pos = chunk_end;
     }
 
     // Wait for the ring buffer to drain (finish playing)
-    while producer.slots() < buffer_frames && !stop.load(Ordering::Relaxed) {
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        // When slots == capacity, the buffer is empty (all consumed)
+        if producer.slots() >= buffer_frames {
+            break;
+        }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 
-    // Small grace period for the last samples to reach the speaker
+    // Grace period for the last samples to reach the speaker
     if !stop.load(Ordering::Relaxed) {
         std::thread::sleep(std::time::Duration::from_millis(200));
     }

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -6,6 +6,36 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{SampleRate, StreamConfig};
 use rtrb::RingBuffer;
 
+/// Information about an available audio output device.
+#[derive(Debug)]
+pub struct AudioDevice {
+    pub name: String,
+    pub is_default: bool,
+}
+
+/// List all available audio output devices.
+pub fn list_devices() -> Result<Vec<AudioDevice>> {
+    let host = cpal::default_host();
+    let default_name = host
+        .default_output_device()
+        .and_then(|d| d.name().ok())
+        .unwrap_or_default();
+
+    let devices: Vec<AudioDevice> = host
+        .output_devices()
+        .context("Failed to enumerate audio output devices")?
+        .filter_map(|d| {
+            let name = d.name().ok()?;
+            Some(AudioDevice {
+                is_default: name == default_name,
+                name,
+            })
+        })
+        .collect();
+
+    Ok(devices)
+}
+
 /// Play pre-decoded f32 samples through CPAL.
 ///
 /// Uses an rtrb ring buffer: the main thread pushes samples,
@@ -21,9 +51,10 @@ pub fn play_audio(
     let host = cpal::default_host();
     let device = host
         .default_output_device()
-        .context("No audio output device found")?;
+        .context("No audio output device found. Check your system audio settings.")?;
 
-    tracing::info!("Audio device: {}", device.name().unwrap_or_default());
+    let device_name = device.name().unwrap_or_else(|_| "Unknown".into());
+    tracing::info!("Audio device: {device_name}");
 
     let config = StreamConfig {
         channels: channels as u16,
@@ -54,9 +85,17 @@ pub fn play_audio(
             },
             None,
         )
-        .context("Failed to build audio output stream")?;
+        .with_context(|| {
+            format!(
+                "Failed to build audio stream on '{device_name}' \
+                 ({}Hz, {}ch). The device may not support this format.",
+                sample_rate, channels
+            )
+        })?;
 
-    stream.play().context("Failed to start audio playback")?;
+    stream.play().with_context(|| {
+        format!("Failed to start playback on '{device_name}'")
+    })?;
 
     // Push samples into the ring buffer from the main thread.
     // Volume scaling happens here (producer side), not in the callback.
@@ -70,7 +109,6 @@ pub fn play_audio(
         let chunk_end = (pos + slots).min(samples.len());
         let chunk = &samples[pos..chunk_end];
         for &s in chunk {
-            // push won't fail here because we checked slots
             let _ = producer.push(s * volume);
         }
         pos = chunk_end;
@@ -81,7 +119,6 @@ pub fn play_audio(
         if stop.load(Ordering::Relaxed) {
             break;
         }
-        // When slots == capacity, the buffer is empty (all consumed)
         if producer.slots() >= buffer_frames {
             break;
         }
@@ -95,4 +132,54 @@ pub fn play_audio(
 
     drop(stream);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_devices_returns_without_panic() {
+        // This test validates that device enumeration doesn't panic.
+        // On CI (no audio device), it may return an empty list — that's OK.
+        let result = list_devices();
+        match result {
+            Ok(devices) => {
+                for d in &devices {
+                    assert!(!d.name.is_empty(), "Device name should not be empty");
+                }
+                // If there's a default device, exactly one should be marked default
+                if !devices.is_empty() {
+                    let default_count = devices.iter().filter(|d| d.is_default).count();
+                    assert!(
+                        default_count <= 1,
+                        "At most one device should be the default"
+                    );
+                }
+            }
+            Err(_) => {
+                // On headless CI, device enumeration may fail — acceptable
+            }
+        }
+    }
+
+    #[test]
+    fn play_audio_with_empty_samples_returns_ok() {
+        // Playing zero samples should complete immediately without crash
+        let stop = Arc::new(AtomicBool::new(false));
+        // On CI without audio device, this will fail at device selection — that's OK
+        let result = play_audio(&[], 44100, 2, 1.0, &stop);
+        match result {
+            Ok(()) => {} // Completed fine
+            Err(e) => {
+                let msg = format!("{e:#}");
+                assert!(
+                    msg.contains("No audio output device")
+                        || msg.contains("Failed to build")
+                        || msg.contains("Failed to start"),
+                    "Unexpected error: {msg}"
+                );
+            }
+        }
+    }
 }

--- a/src/core/track.rs
+++ b/src/core/track.rs
@@ -11,6 +11,7 @@ pub struct Track {
 #[derive(Debug, Clone)]
 pub enum TrackSource {
     File(PathBuf),
+    #[allow(dead_code)] // Used in future phases (radio, podcasts)
     Url(String),
 }
 
@@ -18,7 +19,9 @@ pub enum TrackSource {
 pub struct TrackMetadata {
     pub title: Option<String>,
     pub artist: Option<String>,
+    #[allow(dead_code)] // Used in future phases (library browsing)
     pub album: Option<String>,
+    #[allow(dead_code)] // Used in future phases (progress bar)
     pub duration: Option<Duration>,
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,4 +1,4 @@
-/// Shared audio types used across layers.
+//! Shared audio types used across layers.
 
 /// Volume represented in decibels.
 #[derive(Debug, Clone, Copy)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@
 //   tui/      — terminal UI (ratatui)
 //   ipc/      — remote control protocol
 
+mod backend;
 mod core;
 mod playback;
-mod backend;
 mod providers;
 
 use std::path::PathBuf;
@@ -19,7 +19,11 @@ use anyhow::Result;
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(name = "kora", version, about = "A fast, multi-source terminal audio player")]
+#[command(
+    name = "kora",
+    version,
+    about = "A fast, multi-source terminal audio player"
+)]
 struct Cli {
     /// Files, directories, or URLs to play
     #[arg(value_name = "INPUT")]

--- a/src/playback/decoder.rs
+++ b/src/playback/decoder.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use symphonia::core::audio::SampleBuffer;
-use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::codecs::{CODEC_TYPE_NULL, DecoderOptions};
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;

--- a/src/playback/decoder.rs
+++ b/src/playback/decoder.rs
@@ -16,6 +16,7 @@ pub struct DecodedAudio {
     pub samples: Vec<f32>,
     pub sample_rate: u32,
     pub channels: usize,
+    #[allow(dead_code)] // Exposed for future benchmarking/diagnostics
     pub decode_time_ms: f64,
 }
 

--- a/src/playback/decoder.rs
+++ b/src/playback/decoder.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::path::Path;
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use symphonia::core::audio::SampleBuffer;
@@ -10,15 +11,19 @@ use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
 /// Decoded audio data ready for the audio pipeline.
+#[derive(Debug)]
 pub struct DecodedAudio {
     pub samples: Vec<f32>,
     pub sample_rate: u32,
     pub channels: usize,
+    pub decode_time_ms: f64,
 }
 
 /// Decode an entire audio file into f32 samples.
-/// For Spike 1 this loads the full file into memory.
-/// Future: streaming decode into a ring buffer.
+///
+/// Handles corrupt and truncated files gracefully: decode errors on individual
+/// packets are logged and skipped rather than propagating as fatal errors.
+/// Only a complete failure to open or probe the file is fatal.
 pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
     let file = File::open(path).with_context(|| format!("Cannot open {}", path.display()))?;
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
@@ -35,7 +40,7 @@ pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
             &FormatOptions::default(),
             &MetadataOptions::default(),
         )
-        .context("Unsupported or corrupt audio file")?;
+        .with_context(|| format!("Unsupported or corrupt audio file: {}", path.display()))?;
 
     let mut format = probed.format;
 
@@ -43,22 +48,26 @@ pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
         .tracks()
         .iter()
         .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .context("No supported audio track found")?;
+        .with_context(|| format!("No supported audio track in {}", path.display()))?;
 
     let codec_params = track.codec_params.clone();
     let track_id = track.id;
 
-    let sample_rate = codec_params.sample_rate.context("Unknown sample rate")?;
+    let sample_rate = codec_params
+        .sample_rate
+        .with_context(|| format!("Unknown sample rate in {}", path.display()))?;
     let channels = codec_params
         .channels
         .map(|c| c.count())
-        .context("Unknown channel count")?;
+        .with_context(|| format!("Unknown channel count in {}", path.display()))?;
 
     let mut decoder = symphonia::default::get_codecs()
         .make(&codec_params, &DecoderOptions::default())
-        .context("Failed to create decoder")?;
+        .with_context(|| format!("Failed to create decoder for {}", path.display()))?;
 
     let mut all_samples: Vec<f32> = Vec::new();
+    let mut decode_errors = 0u32;
+    let start = Instant::now();
 
     loop {
         let packet = match format.next_packet() {
@@ -68,34 +77,122 @@ pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
             {
                 break; // End of stream
             }
-            Err(e) => return Err(e.into()),
+            Err(symphonia::core::errors::Error::DecodeError(msg)) => {
+                // Corrupt packet — skip it, don't crash
+                decode_errors += 1;
+                tracing::warn!("Skipping corrupt packet in {}: {msg}", path.display());
+                continue;
+            }
+            Err(e) => return Err(e).context(format!("Read error in {}", path.display())),
         };
 
         if packet.track_id() != track_id {
             continue;
         }
 
-        let decoded = decoder.decode(&packet)?;
-        let spec = *decoded.spec();
-        let duration = decoded.capacity();
+        match decoder.decode(&packet) {
+            Ok(decoded) => {
+                let spec = *decoded.spec();
+                let duration = decoded.capacity();
+                let mut sample_buf = SampleBuffer::<f32>::new(duration as u64, spec);
+                sample_buf.copy_interleaved_ref(decoded);
+                all_samples.extend_from_slice(sample_buf.samples());
+            }
+            Err(symphonia::core::errors::Error::DecodeError(msg)) => {
+                // Corrupt frame — skip it, continue decoding
+                decode_errors += 1;
+                tracing::warn!("Skipping corrupt frame in {}: {msg}", path.display());
+                continue;
+            }
+            Err(e) => return Err(e).context(format!("Decode error in {}", path.display())),
+        }
+    }
 
-        let mut sample_buf = SampleBuffer::<f32>::new(duration as u64, spec);
-        sample_buf.copy_interleaved_ref(decoded);
+    let decode_time = start.elapsed();
+    let decode_time_ms = decode_time.as_secs_f64() * 1000.0;
+    let audio_duration_s = all_samples.len() as f64 / (sample_rate as f64 * channels as f64);
 
-        all_samples.extend_from_slice(sample_buf.samples());
+    if all_samples.is_empty() {
+        anyhow::bail!("No audio samples decoded from {}", path.display());
     }
 
     tracing::info!(
-        "Decoded {} samples ({:.1}s, {}Hz, {}ch)",
-        all_samples.len(),
-        all_samples.len() as f32 / (sample_rate as f32 * channels as f32),
+        "Decoded {:.1}s audio in {:.0}ms ({:.0}x realtime, {}Hz, {}ch{})",
+        audio_duration_s,
+        decode_time_ms,
+        (audio_duration_s * 1000.0) / decode_time_ms,
         sample_rate,
-        channels
+        channels,
+        if decode_errors > 0 {
+            format!(", {decode_errors} errors skipped")
+        } else {
+            String::new()
+        }
     );
 
     Ok(DecodedAudio {
         samples: all_samples,
         sample_rate,
         channels,
+        decode_time_ms,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn decode_nonexistent_file_returns_error() {
+        let result = decode_file(Path::new("/nonexistent/file.mp3"));
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("Cannot open"),
+            "Expected 'Cannot open' in error: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_empty_file_returns_error() {
+        let dir = std::env::temp_dir().join("kora_test_decode");
+        std::fs::create_dir_all(&dir).unwrap();
+        let empty_file = dir.join("empty.mp3");
+        File::create(&empty_file).unwrap();
+
+        let result = decode_file(&empty_file);
+        assert!(result.is_err(), "Empty file should fail to decode");
+
+        std::fs::remove_file(&empty_file).ok();
+    }
+
+    #[test]
+    fn decode_garbage_file_returns_error() {
+        let dir = std::env::temp_dir().join("kora_test_decode");
+        std::fs::create_dir_all(&dir).unwrap();
+        let garbage_file = dir.join("garbage.mp3");
+        let mut f = File::create(&garbage_file).unwrap();
+        f.write_all(&[0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03])
+            .unwrap();
+
+        let result = decode_file(&garbage_file);
+        assert!(result.is_err(), "Garbage file should fail to decode");
+
+        std::fs::remove_file(&garbage_file).ok();
+    }
+
+    #[test]
+    fn decode_unsupported_extension_returns_error() {
+        let dir = std::env::temp_dir().join("kora_test_decode");
+        std::fs::create_dir_all(&dir).unwrap();
+        let txt_file = dir.join("notaudio.txt");
+        let mut f = File::create(&txt_file).unwrap();
+        f.write_all(b"this is not audio").unwrap();
+
+        let result = decode_file(&txt_file);
+        assert!(result.is_err(), "Text file should fail to decode");
+
+        std::fs::remove_file(&txt_file).ok();
+    }
 }

--- a/src/playback/engine.rs
+++ b/src/playback/engine.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result};
 
@@ -20,12 +20,7 @@ pub fn play_tracks(tracks: &[Track], volume_db: f32) -> Result<()> {
             }
         };
 
-        println!(
-            "[{}/{}] {}",
-            i + 1,
-            tracks.len(),
-            track.display_name()
-        );
+        println!("[{}/{}] {}", i + 1, tracks.len(), track.display_name());
 
         let decoded = super::decoder::decode_file(path)
             .with_context(|| format!("Failed to decode {}", path.display()))?;


### PR DESCRIPTION
## Description

Add project documentation, naming rationale, GitHub templates, release workflow, and complete the Phase 0 audio pipeline spikes with error handling and tests.

### What's included

- **Naming rationale**: "Why kora?" section in README explaining the name's connection to the West African kora instrument
- **ROADMAP**: Updated all references to "kora", rewrote the Naming & Branding section with rationale
- **Architecture Decision Records**: ADR-001 through ADR-005 in docs/adr/
- **Audio pipeline hardening**: Corrupt/truncated files are now handled gracefully (skip bad frames, continue playback) with 4 decoder tests and 2 backend tests
- **Device enumeration**: list_devices() function for discovering audio output devices
- **Decode performance**: Logs decode time and realtime multiplier per file
- **CPAL fix**: Replaced unsafe ptr::read/mem::forget with proper Rust ownership for the ring buffer Consumer
- **GitHub templates**: PR template, bug report form, feature request form, issue config
- **Release workflow**: Cross-platform binary builds (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows), GitHub Release with changelog extraction, crates.io publish
- **Community docs**: CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md, CODEOWNERS, FUNDING.yml, dependabot.yml
- **Git policy**: Added to copilot-instructions.md preventing automated commits/pushes

## Related Issues

Closes #1, closes #2, closes #3

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI / infrastructure

## Module

- [x] `playback/` — Decode, DSP, state machine
- [x] `backend/` — Audio output (CPAL)
- [x] `docs/` — Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (6 tests, 0 failures)
- [ ] `cargo clippy -- -D warnings` reports no warnings (dead code warnings for future-use fields)
- [ ] `cargo fmt` has been applied (pre-existing formatting from scaffold)
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)