### PR TITLE
feat: add TUI player, 10-band graphic EQ, and pause/resume

### DIFF
--- a/.github/skills/pr-ready/SKILL.md
+++ b/.github/skills/pr-ready/SKILL.md
@@ -38,14 +38,19 @@ Prepare a branch for pull request: generate a PR description from the diff AND u
    - Read `CHANGELOG.md` and note the existing `## [Unreleased]` section contents.
    - Understand the Keep a Changelog format used (Added, Changed, Deprecated, Removed, Fixed, Security).
 
-### Phase 2: Run quality checks
+### Phase 2: Fix and verify quality
 
-1. **Verify the branch passes checks** (for the PR checklist)
-   Run the standard Rust checks:
-   - `cargo fmt -- --check`
-   - `cargo clippy -- -D warnings`
-   - `cargo test`
-   - Note which checks pass/fail to fill in the checklist accurately.
+1. **Fix formatting and lint issues first** — do not just report them.
+   Run these in order, fixing any issues before proceeding:
+
+   - Run `cargo fmt` (not `--check` — actually apply formatting fixes)
+   - Run `cargo clippy -- -D warnings`. If there are errors:
+     - Fix each clippy error in the source code
+     - Re-run until clippy passes cleanly
+   - Run `cargo test` to verify nothing is broken
+
+   **Only proceed to Phase 3 when all three pass.** Do not generate a PR
+   description with failing checks — fix the code first.
 
 ### Phase 3: Generate the PR description
 
@@ -57,7 +62,9 @@ Prepare a branch for pull request: generate a PR description from the diff AND u
    - **Related Issues**: Check commit messages for issue references (#123). If none, leave placeholder.
    - **Type of Change**: Check the appropriate box(es) based on diff content.
    - **Module**: Note which modules were touched (`playback/`, `tui/`, `providers/`, etc.)
-   - **Checklist**: Mark items based on the results from the quality checks step.
+   - **Checklist**: Since Phase 2 fixes all issues before reaching here, all quality
+     checklist items (`cargo test`, `cargo clippy`, `cargo fmt`) should be marked as passing.
+     Only mark an item as failing if it genuinely cannot be fixed.
 
 2. **Quality guidelines for the PR description**
    - Do NOT reference internal planning documents (roadmap phases, ADR numbers) — describe actual changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dual MIT + Apache 2.0 licensing
 - Graceful handling of corrupt and truncated audio files (skip bad frames, continue playback)
 - Decode performance reporting in log output (realtime multiplier)
+- TUI with track info, progress bar, and transport status (Playing/Paused/Stopped)
+- Keyboard controls: Space (play/pause), n/p (next/prev), +/- (volume), s (stop), q (quit)
+- Playlist panel showing queue with current track highlighted
+- 10-band graphic equalizer with 11 presets (Flat, Rock, Pop, Jazz, Classical, Electronic, Hip Hop, Acoustic, Bass Boost, Treble Boost, Vocal)
+- `--eq-preset` CLI flag and `--list-eq-presets` to show available presets
+- Low-shelf filter at 31Hz and high-shelf at highest band for natural EQ response
 
 ### Fixed
 
 - Audio playback crash caused by unsafe ring buffer Consumer handling in CPAL callback
+- Pause/resume: playback now pauses and resumes in place without re-decoding the track

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -43,6 +43,7 @@ pub fn list_devices() -> Result<Vec<AudioDevice>> {
 /// Uses an rtrb ring buffer: the main thread pushes samples,
 /// the CPAL audio callback pulls them. The callback thread obeys
 /// real-time safety rules (no alloc, no locks, no I/O).
+#[allow(dead_code)] // Used by headless/non-TUI mode (future)
 pub fn play_audio(
     samples: &[f32],
     sample_rate: u32,
@@ -128,6 +129,91 @@ pub fn play_audio(
     }
 
     // Grace period for the last samples to reach the speaker
+    if !stop.load(Ordering::Relaxed) {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    drop(stream);
+    Ok(())
+}
+
+/// Play audio with position tracking and pause/resume support.
+pub fn play_audio_with_position(
+    samples: &[f32],
+    sample_rate: u32,
+    channels: usize,
+    volume: f32,
+    stop: &Arc<AtomicBool>,
+    pause: &Arc<AtomicBool>,
+    samples_played: &AtomicU64,
+) -> Result<()> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .context("No audio output device found.")?;
+
+    let config = StreamConfig {
+        channels: channels as u16,
+        sample_rate: SampleRate(sample_rate),
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let buffer_frames = (sample_rate as usize * channels * 200) / 1000;
+    let (mut producer, mut consumer) = RingBuffer::new(buffer_frames);
+
+    let stream = device
+        .build_output_stream(
+            &config,
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                for sample in data.iter_mut() {
+                    match consumer.pop() {
+                        Ok(s) => *sample = s,
+                        Err(_) => *sample = 0.0,
+                    }
+                }
+            },
+            move |err| {
+                eprintln!("Audio stream error: {err}");
+            },
+            None,
+        )
+        .context("Failed to build audio stream")?;
+
+    stream.play().context("Failed to start playback")?;
+
+    let mut pos = 0;
+    while pos < samples.len() && !stop.load(Ordering::Relaxed) {
+        // When paused, sleep without pushing — the callback drains to silence
+        if pause.load(Ordering::Relaxed) {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            continue;
+        }
+
+        let slots = producer.slots();
+        if slots == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            continue;
+        }
+        let chunk_end = (pos + slots).min(samples.len());
+        let chunk = &samples[pos..chunk_end];
+        for &s in chunk {
+            let _ = producer.push(s * volume);
+        }
+        pos = chunk_end;
+        samples_played.store(pos as u64, Ordering::Relaxed);
+    }
+
+    // Wait for drain
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        if producer.slots() >= buffer_frames {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
     if !stop.load(Ordering::Relaxed) {
         std::thread::sleep(std::time::Duration::from_millis(200));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod backend;
 mod core;
 mod playback;
 mod providers;
+mod tui;
 
 use std::path::PathBuf;
 
@@ -32,6 +33,14 @@ struct Cli {
     /// Volume in dB (e.g., -3 for quieter, 0 for default)
     #[arg(long, default_value = "0")]
     volume: f32,
+
+    /// EQ preset name (e.g., Rock, Jazz, Pop, Classical, Bass Boost)
+    #[arg(long, value_name = "PRESET")]
+    eq_preset: Option<String>,
+
+    /// List available EQ presets and exit
+    #[arg(long)]
+    list_eq_presets: bool,
 }
 
 fn main() -> Result<()> {
@@ -43,6 +52,16 @@ fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    if cli.list_eq_presets {
+        println!("Available EQ presets:");
+        for name in playback::eq::preset_names() {
+            let preset = playback::eq::find_preset(name).unwrap();
+            let gains: Vec<String> = preset.gains.iter().map(|g| format!("{g:+.0}")).collect();
+            println!("  {:<14} [{}]", name, gains.join(", "));
+        }
+        return Ok(());
+    }
 
     if cli.inputs.is_empty() {
         eprintln!("Usage: kora <file.mp3|file.flac|...>");
@@ -59,7 +78,9 @@ fn main() -> Result<()> {
 
     tracing::info!("Playing {} track(s)", tracks.len());
 
-    playback::engine::play_tracks(&tracks, cli.volume)?;
+    // Launch TUI player
+    let player = playback::player::Player::new(tracks, cli.volume, cli.eq_preset.as_deref())?;
+    tui::app::run(player)?;
 
     Ok(())
 }

--- a/src/playback/dsp.rs
+++ b/src/playback/dsp.rs
@@ -1,0 +1,276 @@
+//! Biquad IIR filter — Transposed Direct Form II.
+//!
+//! Used for the 10-band graphic EQ. Each filter is O(1) per sample with
+//! two delay elements per channel. Coefficients are pre-normalized (divided
+//! by a0) on creation so no per-sample division is needed.
+//!
+//! Reference: Robert Bristow-Johnson's Audio EQ Cookbook.
+
+use std::f64::consts::PI;
+
+/// Pre-normalized biquad coefficients (already divided by a0).
+#[derive(Debug, Clone, Copy)]
+pub struct BiquadCoeffs {
+    b0: f64,
+    b1: f64,
+    b2: f64,
+    a1: f64,
+    a2: f64,
+}
+
+/// Per-channel filter state for Transposed Direct Form II.
+#[derive(Debug, Clone, Copy, Default)]
+struct ChannelState {
+    s1: f64,
+    s2: f64,
+}
+
+/// A biquad filter with per-channel state.
+#[derive(Debug, Clone)]
+pub struct BiquadFilter {
+    coeffs: BiquadCoeffs,
+    state: Vec<ChannelState>,
+}
+
+impl BiquadCoeffs {
+    /// Peaking EQ filter for mid-band frequencies.
+    pub fn peaking(sample_rate: f64, freq: f64, gain_db: f64, bw_octaves: f64) -> Self {
+        let a = 10.0_f64.powf(gain_db / 40.0);
+        let w0 = 2.0 * PI * freq / sample_rate;
+
+        let alpha = w0.sin() * (2.0_f64.ln() / 2.0 * bw_octaves * w0 / w0.sin()).sinh() / 2.0;
+
+        let cos_w0 = w0.cos();
+
+        let b0 = 1.0 + alpha * a;
+        let b1 = -2.0 * cos_w0;
+        let b2 = 1.0 - alpha * a;
+        let a0 = 1.0 + alpha / a;
+        let a1 = -2.0 * cos_w0;
+        let a2 = 1.0 - alpha / a;
+
+        Self::normalized(b0, b1, b2, a0, a1, a2)
+    }
+
+    /// Low-shelf filter for the lowest EQ band.
+    pub fn low_shelf(sample_rate: f64, freq: f64, gain_db: f64) -> Self {
+        let a = 10.0_f64.powf(gain_db / 40.0);
+        let w0 = 2.0 * PI * freq / sample_rate;
+        let cos_w0 = w0.cos();
+        let sin_w0 = w0.sin();
+        let alpha = sin_w0 / 2.0 * (2.0_f64).sqrt(); // S = 1.0 (slope)
+        let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+
+        let b0 = a * ((a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha);
+        let b1 = 2.0 * a * ((a - 1.0) - (a + 1.0) * cos_w0);
+        let b2 = a * ((a + 1.0) - (a - 1.0) * cos_w0 - two_sqrt_a_alpha);
+        let a0 = (a + 1.0) + (a - 1.0) * cos_w0 + two_sqrt_a_alpha;
+        let a1 = -2.0 * ((a - 1.0) + (a + 1.0) * cos_w0);
+        let a2 = (a + 1.0) + (a - 1.0) * cos_w0 - two_sqrt_a_alpha;
+
+        Self::normalized(b0, b1, b2, a0, a1, a2)
+    }
+
+    /// High-shelf filter for the highest EQ band.
+    pub fn high_shelf(sample_rate: f64, freq: f64, gain_db: f64) -> Self {
+        let a = 10.0_f64.powf(gain_db / 40.0);
+        let w0 = 2.0 * PI * freq / sample_rate;
+        let cos_w0 = w0.cos();
+        let sin_w0 = w0.sin();
+        let alpha = sin_w0 / 2.0 * (2.0_f64).sqrt();
+        let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+
+        let b0 = a * ((a + 1.0) + (a - 1.0) * cos_w0 + two_sqrt_a_alpha);
+        let b1 = -2.0 * a * ((a - 1.0) + (a + 1.0) * cos_w0);
+        let b2 = a * ((a + 1.0) + (a - 1.0) * cos_w0 - two_sqrt_a_alpha);
+        let a0 = (a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha;
+        let a1 = 2.0 * ((a - 1.0) - (a + 1.0) * cos_w0);
+        let a2 = (a + 1.0) - (a - 1.0) * cos_w0 - two_sqrt_a_alpha;
+
+        Self::normalized(b0, b1, b2, a0, a1, a2)
+    }
+
+    /// Bypass (unity gain, no filtering).
+    pub fn bypass() -> Self {
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+        }
+    }
+
+    fn normalized(b0: f64, b1: f64, b2: f64, a0: f64, a1: f64, a2: f64) -> Self {
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+        }
+    }
+}
+
+impl BiquadFilter {
+    pub fn new(coeffs: BiquadCoeffs, channels: usize) -> Self {
+        Self {
+            coeffs,
+            state: vec![ChannelState::default(); channels],
+        }
+    }
+
+    /// Process one sample for a given channel using Transposed Direct Form II.
+    /// No allocation, no branching — suitable for tight audio loops.
+    #[inline(always)]
+    pub fn process(&mut self, sample: f32, channel: usize) -> f32 {
+        let x = sample as f64;
+        let s = &mut self.state[channel];
+        let c = &self.coeffs;
+
+        let y = c.b0 * x + s.s1;
+        s.s1 = c.b1 * x - c.a1 * y + s.s2;
+        s.s2 = c.b2 * x - c.a2 * y;
+
+        y as f32
+    }
+
+    /// Reset filter state (call on track boundaries to avoid clicks).
+    #[allow(dead_code)] // Used by Equalizer::reset and future live EQ changes
+    pub fn reset(&mut self) {
+        for s in &mut self.state {
+            s.s1 = 0.0;
+            s.s2 = 0.0;
+        }
+    }
+
+    /// Update coefficients (e.g., when EQ gain changes).
+    #[allow(dead_code)] // Used by future live EQ adjustment
+    pub fn set_coeffs(&mut self, coeffs: BiquadCoeffs) {
+        self.coeffs = coeffs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bypass_filter_passes_signal_unchanged() {
+        let mut filter = BiquadFilter::new(BiquadCoeffs::bypass(), 1);
+        let input: Vec<f32> = (0..100).map(|i| (i as f32) * 0.01).collect();
+        let output: Vec<f32> = input.iter().map(|&s| filter.process(s, 0)).collect();
+        for (i, (a, b)) in input.iter().zip(output.iter()).enumerate() {
+            assert!((a - b).abs() < 1e-6, "Sample {i}: input={a}, output={b}");
+        }
+    }
+
+    #[test]
+    fn peaking_filter_with_zero_gain_passes_signal() {
+        let coeffs = BiquadCoeffs::peaking(44100.0, 1000.0, 0.0, 1.0);
+        let mut filter = BiquadFilter::new(coeffs, 1);
+        // DC signal should pass through unchanged with 0dB gain
+        for _ in 0..100 {
+            let out = filter.process(1.0, 0);
+            // After settling, should be ~1.0
+            assert!(out.is_finite());
+        }
+        let out = filter.process(1.0, 0);
+        assert!(
+            (out - 1.0).abs() < 0.01,
+            "0dB peaking should pass DC: got {out}"
+        );
+    }
+
+    #[test]
+    fn peaking_filter_boosts_at_center_frequency() {
+        let coeffs = BiquadCoeffs::peaking(44100.0, 1000.0, 12.0, 1.0);
+        let mut filter = BiquadFilter::new(coeffs, 1);
+
+        // Generate a 1kHz sine wave
+        let sample_rate = 44100.0_f32;
+        let freq = 1000.0_f32;
+        let mut max_in: f32 = 0.0;
+        let mut max_out: f32 = 0.0;
+
+        for i in 0..4410 {
+            let t = i as f32 / sample_rate;
+            let sample = (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5;
+            let out = filter.process(sample, 0);
+            if i > 1000 {
+                // After settling
+                max_in = max_in.max(sample.abs());
+                max_out = max_out.max(out.abs());
+            }
+        }
+
+        let gain_db = 20.0 * (max_out / max_in).log10();
+        // +12dB boost should yield roughly 8-16dB measured gain
+        assert!(
+            gain_db > 6.0 && gain_db < 18.0,
+            "Expected ~12dB boost at 1kHz, got {gain_db:.1}dB"
+        );
+    }
+
+    #[test]
+    fn filter_reset_clears_state() {
+        let coeffs = BiquadCoeffs::peaking(44100.0, 1000.0, 12.0, 1.0);
+        let mut filter = BiquadFilter::new(coeffs, 2);
+
+        // Process some samples
+        for i in 0..100 {
+            filter.process((i as f32) * 0.01, 0);
+            filter.process((i as f32) * 0.01, 1);
+        }
+
+        filter.reset();
+
+        for s in &filter.state {
+            assert_eq!(s.s1, 0.0);
+            assert_eq!(s.s2, 0.0);
+        }
+    }
+
+    #[test]
+    fn low_shelf_boosts_low_frequencies() {
+        let coeffs = BiquadCoeffs::low_shelf(44100.0, 100.0, 12.0);
+        let mut filter = BiquadFilter::new(coeffs, 1);
+
+        // DC (0 Hz) should be boosted
+        for _ in 0..200 {
+            filter.process(1.0, 0);
+        }
+        let dc_out = filter.process(1.0, 0);
+        assert!(
+            dc_out > 1.5,
+            "Low shelf +12dB should boost DC: got {dc_out}"
+        );
+    }
+
+    #[test]
+    fn high_shelf_boosts_high_frequencies() {
+        let coeffs = BiquadCoeffs::high_shelf(44100.0, 8000.0, 12.0);
+        let mut filter = BiquadFilter::new(coeffs, 1);
+
+        // Generate a ~16kHz sine wave (above the shelf frequency)
+        let sample_rate = 44100.0_f32;
+        let freq = 16000.0_f32;
+        let mut max_in: f32 = 0.0;
+        let mut max_out: f32 = 0.0;
+
+        for i in 0..4410 {
+            let t = i as f32 / sample_rate;
+            let sample = (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5;
+            let out = filter.process(sample, 0);
+            if i > 1000 {
+                max_in = max_in.max(sample.abs());
+                max_out = max_out.max(out.abs());
+            }
+        }
+
+        assert!(
+            max_out > max_in * 1.5,
+            "High shelf should boost 16kHz: in={max_in}, out={max_out}"
+        );
+    }
+}

--- a/src/playback/engine.rs
+++ b/src/playback/engine.rs
@@ -5,11 +5,28 @@ use anyhow::{Context, Result};
 
 use crate::core::track::{Track, TrackSource};
 use crate::core::types::Volume;
+use crate::playback::eq::{self, Equalizer};
 
-/// Play a list of tracks sequentially.
-/// Spike 1: decode fully into memory, then stream to CPAL via rtrb.
-pub fn play_tracks(tracks: &[Track], volume_db: f32) -> Result<()> {
+/// Play a list of tracks sequentially with optional EQ (non-TUI mode).
+#[allow(dead_code)] // Used by headless/non-TUI mode (future)
+pub fn play_tracks(tracks: &[Track], volume_db: f32, eq_preset: Option<&str>) -> Result<()> {
     let volume = Volume(volume_db);
+
+    // Resolve EQ preset
+    let preset = match eq_preset {
+        Some(name) => {
+            let p = eq::find_preset(name).with_context(|| {
+                format!(
+                    "Unknown EQ preset '{}'. Available: {}",
+                    name,
+                    eq::preset_names().join(", ")
+                )
+            })?;
+            tracing::info!("EQ preset: {}", p.name);
+            Some(p)
+        }
+        None => None,
+    };
 
     for (i, track) in tracks.iter().enumerate() {
         let path = match &track.source {
@@ -25,16 +42,26 @@ pub fn play_tracks(tracks: &[Track], volume_db: f32) -> Result<()> {
         let decoded = super::decoder::decode_file(path)
             .with_context(|| format!("Failed to decode {}", path.display()))?;
 
+        // Apply EQ to decoded samples
+        let samples = if let Some(p) = preset {
+            let mut eq = Equalizer::new(decoded.sample_rate, decoded.channels);
+            eq.apply_preset(p);
+            let mut buf = decoded.samples;
+            eq.process(&mut buf, decoded.channels);
+            buf
+        } else {
+            decoded.samples
+        };
+
         let stop = Arc::new(AtomicBool::new(false));
 
-        // Set up Ctrl+C handler for this track
         let stop_clone = stop.clone();
         let _ = ctrlc::set_handler(move || {
             stop_clone.store(true, Ordering::Relaxed);
         });
 
         crate::backend::cpal_backend::play_audio(
-            &decoded.samples,
+            &samples,
             decoded.sample_rate,
             decoded.channels,
             volume.as_linear(),

--- a/src/playback/eq.rs
+++ b/src/playback/eq.rs
@@ -226,7 +226,7 @@ mod tests {
             assert!(!preset.name.is_empty());
             for &gain in &preset.gains {
                 assert!(
-                    gain >= -12.0 && gain <= 12.0,
+                    (-12.0..=12.0).contains(&gain),
                     "Preset '{}' has out-of-range gain: {gain}",
                     preset.name
                 );

--- a/src/playback/eq.rs
+++ b/src/playback/eq.rs
@@ -1,0 +1,316 @@
+//! 10-band graphic equalizer with presets.
+//!
+//! Uses biquad IIR filters (one per band) applied in series. The first band
+//! is a low-shelf, the last band is a high-shelf (or bypassed near Nyquist),
+//! and the middle 8 bands are peaking EQ filters.
+//!
+//! Filter coefficients are computed once per preset change (not per sample).
+//! Processing is O(1) per sample per band — 10 multiply-accumulates total.
+
+use super::dsp::{BiquadCoeffs, BiquadFilter};
+
+/// Standard graphic EQ center frequencies (Hz).
+pub const BAND_FREQUENCIES: [f64; 10] = [
+    31.0, 62.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0,
+];
+
+/// Bandwidth in octaves for peaking EQ bands.
+const BANDWIDTH_OCTAVES: f64 = 1.0;
+
+/// A named EQ preset with 10 band gain values in dB.
+#[derive(Debug, Clone)]
+pub struct EqPreset {
+    pub name: &'static str,
+    pub gains: [f32; 10],
+}
+
+/// Built-in EQ presets.
+pub const PRESETS: &[EqPreset] = &[
+    EqPreset {
+        name: "Flat",
+        gains: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    },
+    EqPreset {
+        name: "Rock",
+        gains: [4.0, 3.0, 0.0, -2.0, -1.0, 2.0, 4.0, 5.0, 5.0, 4.0],
+    },
+    EqPreset {
+        name: "Pop",
+        gains: [-1.0, 1.0, 3.0, 4.0, 3.0, 0.0, -1.0, -1.0, 1.0, 2.0],
+    },
+    EqPreset {
+        name: "Jazz",
+        gains: [3.0, 2.0, 0.0, 1.0, -1.0, -1.0, 0.0, 1.0, 2.0, 3.0],
+    },
+    EqPreset {
+        name: "Classical",
+        gains: [3.0, 2.0, -1.0, -1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+    },
+    EqPreset {
+        name: "Electronic",
+        gains: [4.0, 3.0, 1.0, 0.0, -2.0, 1.0, 0.0, 2.0, 4.0, 4.0],
+    },
+    EqPreset {
+        name: "Hip Hop",
+        gains: [5.0, 4.0, 1.0, 2.0, -1.0, -1.0, 1.0, 0.0, 2.0, 3.0],
+    },
+    EqPreset {
+        name: "Acoustic",
+        gains: [3.0, 1.0, 0.0, 1.0, 2.0, 1.0, 2.0, 3.0, 2.0, 1.0],
+    },
+    EqPreset {
+        name: "Bass Boost",
+        gains: [6.0, 5.0, 4.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    },
+    EqPreset {
+        name: "Treble Boost",
+        gains: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 4.0, 5.0, 6.0],
+    },
+    EqPreset {
+        name: "Vocal",
+        gains: [-2.0, -1.0, 0.0, 2.0, 4.0, 4.0, 3.0, 1.0, 0.0, -1.0],
+    },
+];
+
+/// Find a preset by name (case-insensitive).
+pub fn find_preset(name: &str) -> Option<&'static EqPreset> {
+    PRESETS.iter().find(|p| p.name.eq_ignore_ascii_case(name))
+}
+
+/// List all available preset names.
+pub fn preset_names() -> Vec<&'static str> {
+    PRESETS.iter().map(|p| p.name).collect()
+}
+
+/// The 10-band graphic equalizer.
+pub struct Equalizer {
+    filters: Vec<BiquadFilter>,
+    channels: usize,
+    sample_rate: f64,
+    gains: [f32; 10],
+    active_bands: usize,
+}
+
+impl Equalizer {
+    /// Create a new equalizer for the given sample rate and channel count.
+    /// Starts with flat (0dB) gains.
+    pub fn new(sample_rate: u32, channels: usize) -> Self {
+        let sr = sample_rate as f64;
+        let nyquist = sr * 0.45; // Guard: skip bands too close to Nyquist
+
+        let active_bands = BAND_FREQUENCIES.iter().filter(|&&f| f < nyquist).count();
+
+        let gains = [0.0_f32; 10];
+        let filters = Self::build_filters(sr, channels, &gains, active_bands);
+
+        Self {
+            filters,
+            channels,
+            sample_rate: sr,
+            gains,
+            active_bands,
+        }
+    }
+
+    /// Set all 10 band gains at once (e.g., from a preset).
+    pub fn set_gains(&mut self, gains: [f32; 10]) {
+        self.gains = gains;
+        self.filters = Self::build_filters(
+            self.sample_rate,
+            self.channels,
+            &self.gains,
+            self.active_bands,
+        );
+    }
+
+    /// Apply a named preset.
+    pub fn apply_preset(&mut self, preset: &EqPreset) {
+        self.set_gains(preset.gains);
+    }
+
+    /// Get current gain values.
+    #[allow(dead_code)] // Used by future TUI EQ display
+    pub fn gains(&self) -> &[f32; 10] {
+        &self.gains
+    }
+
+    /// Reset all filter state (call between tracks to avoid click artifacts).
+    #[allow(dead_code)] // Used by future streaming decode (reset between tracks)
+    pub fn reset(&mut self) {
+        for f in &mut self.filters {
+            f.reset();
+        }
+    }
+
+    /// Process interleaved f32 samples in-place.
+    /// This is called on the producer/decode side, NOT in the audio callback.
+    pub fn process(&mut self, samples: &mut [f32], channels: usize) {
+        if self.is_flat() {
+            return; // Skip processing if all gains are 0
+        }
+
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let ch = i % channels;
+            for filter in &mut self.filters {
+                *sample = filter.process(*sample, ch);
+            }
+        }
+    }
+
+    /// Returns true if all gains are 0dB (flat) — allows skipping processing.
+    fn is_flat(&self) -> bool {
+        self.gains.iter().all(|&g| g.abs() < 0.01)
+    }
+
+    fn build_filters(
+        sample_rate: f64,
+        channels: usize,
+        gains: &[f32; 10],
+        active_bands: usize,
+    ) -> Vec<BiquadFilter> {
+        BAND_FREQUENCIES
+            .iter()
+            .enumerate()
+            .take(active_bands)
+            .map(|(i, &freq)| {
+                let gain_db = gains[i] as f64;
+
+                // Skip bands with ~0dB gain
+                if gain_db.abs() < 0.01 {
+                    return BiquadFilter::new(BiquadCoeffs::bypass(), channels);
+                }
+
+                let coeffs = if i == 0 {
+                    // Low shelf for the lowest band
+                    BiquadCoeffs::low_shelf(sample_rate, freq, gain_db)
+                } else if i == active_bands - 1 && BAND_FREQUENCIES[i] >= 8000.0 {
+                    // High shelf for the highest active band (if it's 8kHz+)
+                    BiquadCoeffs::high_shelf(sample_rate, freq, gain_db)
+                } else {
+                    // Peaking EQ for all middle bands
+                    BiquadCoeffs::peaking(sample_rate, freq, gain_db, BANDWIDTH_OCTAVES)
+                };
+
+                BiquadFilter::new(coeffs, channels)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flat_eq_does_not_modify_signal() {
+        let mut eq = Equalizer::new(44100, 2);
+        let original: Vec<f32> = (0..200).map(|i| (i as f32) * 0.005).collect();
+        let mut samples = original.clone();
+        eq.process(&mut samples, 2);
+        // Flat EQ should skip processing entirely
+        assert_eq!(original, samples);
+    }
+
+    #[test]
+    fn preset_applies_correctly() {
+        let mut eq = Equalizer::new(44100, 2);
+        let preset = find_preset("Rock").unwrap();
+        eq.apply_preset(preset);
+        assert_eq!(eq.gains()[0], 4.0); // 31Hz = +4dB
+        assert_eq!(eq.gains()[3], -2.0); // 250Hz = -2dB
+    }
+
+    #[test]
+    fn all_presets_exist_and_have_valid_gains() {
+        for preset in PRESETS {
+            assert!(!preset.name.is_empty());
+            for &gain in &preset.gains {
+                assert!(
+                    gain >= -12.0 && gain <= 12.0,
+                    "Preset '{}' has out-of-range gain: {gain}",
+                    preset.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn find_preset_is_case_insensitive() {
+        assert!(find_preset("rock").is_some());
+        assert!(find_preset("ROCK").is_some());
+        assert!(find_preset("Rock").is_some());
+        assert!(find_preset("nonexistent").is_none());
+    }
+
+    #[test]
+    fn eq_handles_low_sample_rate() {
+        // At 22050 Hz, Nyquist is 11025 Hz — 16kHz band should be skipped
+        let eq = Equalizer::new(22050, 1);
+        assert!(
+            eq.active_bands < 10,
+            "Should skip high bands at low sample rates"
+        );
+    }
+
+    #[test]
+    fn eq_processes_mono_and_stereo() {
+        for channels in [1, 2] {
+            let mut eq = Equalizer::new(44100, channels);
+            let preset = find_preset("Bass Boost").unwrap();
+            eq.apply_preset(preset);
+
+            let mut samples: Vec<f32> = (0..4410)
+                .map(|i| {
+                    let t = i as f32 / (44100.0 * channels as f32);
+                    (2.0 * std::f32::consts::PI * 50.0 * t).sin() * 0.5
+                })
+                .collect();
+
+            eq.process(&mut samples, channels);
+
+            // Should not produce NaN or infinity
+            assert!(
+                samples.iter().all(|s| s.is_finite()),
+                "EQ produced non-finite values for {channels}ch"
+            );
+        }
+    }
+
+    #[test]
+    fn reset_clears_state_between_tracks() {
+        let mut eq = Equalizer::new(44100, 2);
+        let preset = find_preset("Rock").unwrap();
+        eq.apply_preset(preset);
+
+        // Process some samples
+        let mut buf = vec![0.5_f32; 200];
+        eq.process(&mut buf, 2);
+
+        // Reset
+        eq.reset();
+
+        // Process again — should produce same result as fresh start
+        let mut eq2 = Equalizer::new(44100, 2);
+        eq2.apply_preset(preset);
+
+        let mut buf1 = vec![0.3_f32; 200];
+        let mut buf2 = buf1.clone();
+        eq.process(&mut buf1, 2);
+        eq2.process(&mut buf2, 2);
+
+        for (a, b) in buf1.iter().zip(buf2.iter()) {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "Reset EQ should match fresh EQ: {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn preset_names_returns_all() {
+        let names = preset_names();
+        assert_eq!(names.len(), PRESETS.len());
+        assert!(names.contains(&"Flat"));
+        assert!(names.contains(&"Rock"));
+    }
+}

--- a/src/playback/mod.rs
+++ b/src/playback/mod.rs
@@ -1,2 +1,5 @@
 pub mod decoder;
+pub mod dsp;
 pub mod engine;
+pub mod eq;
+pub mod player;

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -1,0 +1,323 @@
+//! Playback controller — shared state between the TUI and audio pipeline.
+//!
+//! The controller owns the playback queue and manages the lifecycle of
+//! decode → ring buffer → CPAL output for each track. The TUI sends
+//! commands (play, pause, next, seek) and reads state (position, duration,
+//! current track) without blocking the audio pipeline.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+use crate::backend::cpal_backend;
+use crate::core::track::{Track, TrackSource};
+use crate::core::types::Volume;
+use crate::playback::decoder;
+use crate::playback::eq::{self, EqPreset, Equalizer};
+
+/// Playback state visible to the TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaybackState {
+    Playing,
+    Paused,
+    Stopped,
+}
+
+/// Commands sent from the TUI to the playback controller.
+pub enum PlayerCommand {
+    PlayPause,
+    Stop,
+    NextTrack,
+    PrevTrack,
+    #[allow(dead_code)] // Seek not yet implemented
+    SeekForward(Duration),
+    #[allow(dead_code)]
+    SeekBackward(Duration),
+    VolumeUp,
+    VolumeDown,
+    Quit,
+}
+
+/// Shared playback position updated by the producer thread.
+struct SharedPosition {
+    samples_played: AtomicU64,
+    total_samples: AtomicU64,
+}
+
+/// The playback controller manages the queue and audio pipeline.
+pub struct Player {
+    tracks: Vec<Track>,
+    current_index: usize,
+    volume: Volume,
+    state: PlaybackState,
+    eq_preset: Option<&'static EqPreset>,
+
+    // Current track playback
+    current_samples: Option<Vec<f32>>,
+    current_sample_rate: u32,
+    current_channels: usize,
+    current_duration: Duration,
+    playback_position: Duration,
+    playback_start: Option<Instant>,
+    pause_offset: Duration,
+
+    stop_flag: Arc<AtomicBool>,
+    pause_flag: Arc<AtomicBool>,
+    position: Arc<SharedPosition>,
+}
+
+impl Player {
+    pub fn new(tracks: Vec<Track>, volume_db: f32, eq_preset: Option<&str>) -> Result<Self> {
+        let preset = match eq_preset {
+            Some(name) => Some(eq::find_preset(name).with_context(|| {
+                format!(
+                    "Unknown EQ preset '{}'. Available: {}",
+                    name,
+                    eq::preset_names().join(", ")
+                )
+            })?),
+            None => None,
+        };
+
+        Ok(Self {
+            tracks,
+            current_index: 0,
+            volume: Volume(volume_db),
+            state: PlaybackState::Stopped,
+            eq_preset: preset,
+            current_samples: None,
+            current_sample_rate: 44100,
+            current_channels: 2,
+            current_duration: Duration::ZERO,
+            playback_position: Duration::ZERO,
+            playback_start: None,
+            pause_offset: Duration::ZERO,
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            pause_flag: Arc::new(AtomicBool::new(false)),
+            position: Arc::new(SharedPosition {
+                samples_played: AtomicU64::new(0),
+                total_samples: AtomicU64::new(0),
+            }),
+        })
+    }
+
+    /// Load and start playing the current track.
+    pub fn play_current(&mut self) -> Result<()> {
+        if self.tracks.is_empty() {
+            return Ok(());
+        }
+
+        let track = &self.tracks[self.current_index];
+        let path = match &track.source {
+            TrackSource::File(p) => p.clone(),
+            TrackSource::Url(_) => {
+                tracing::warn!("URL playback not yet supported");
+                return Ok(());
+            }
+        };
+
+        let decoded = decoder::decode_file(&path)
+            .with_context(|| format!("Failed to decode {}", path.display()))?;
+
+        let samples = if let Some(p) = self.eq_preset {
+            let mut eq = Equalizer::new(decoded.sample_rate, decoded.channels);
+            eq.apply_preset(p);
+            let mut buf = decoded.samples;
+            eq.process(&mut buf, decoded.channels);
+            buf
+        } else {
+            decoded.samples
+        };
+
+        let total_samples = samples.len() as u64;
+        let sample_rate = decoded.sample_rate;
+        let channels = decoded.channels;
+
+        self.current_duration =
+            Duration::from_secs_f64(samples.len() as f64 / (sample_rate as f64 * channels as f64));
+        self.current_sample_rate = sample_rate;
+        self.current_channels = channels;
+        self.current_samples = Some(samples);
+        self.playback_position = Duration::ZERO;
+        self.pause_offset = Duration::ZERO;
+
+        self.position
+            .total_samples
+            .store(total_samples, Ordering::Relaxed);
+        self.position.samples_played.store(0, Ordering::Relaxed);
+
+        self.state = PlaybackState::Playing;
+        self.playback_start = Some(Instant::now());
+
+        Ok(())
+    }
+
+    /// Start non-blocking playback of the current loaded samples.
+    /// Returns a JoinHandle that completes when playback finishes.
+    pub fn start_playback(&mut self) -> Option<std::thread::JoinHandle<Result<()>>> {
+        let samples = self.current_samples.take()?;
+        let sample_rate = self.current_sample_rate;
+        let channels = self.current_channels;
+        let volume = self.volume.as_linear();
+
+        // Reset flags for this playback session.
+        self.stop_flag.store(false, Ordering::Relaxed);
+        self.pause_flag.store(false, Ordering::Relaxed);
+        let stop = self.stop_flag.clone();
+        let pause = self.pause_flag.clone();
+        let position = self.position.clone();
+
+        let handle = std::thread::spawn(move || {
+            cpal_backend::play_audio_with_position(
+                &samples,
+                sample_rate,
+                channels,
+                volume,
+                &stop,
+                &pause,
+                &position.samples_played,
+            )
+        });
+
+        Some(handle)
+    }
+
+    /// Handle a command from the TUI.
+    pub fn handle_command(&mut self, cmd: PlayerCommand) -> PlayerAction {
+        match cmd {
+            PlayerCommand::PlayPause => match self.state {
+                PlaybackState::Playing => {
+                    self.state = PlaybackState::Paused;
+                    self.pause_offset = self.current_position();
+                    self.pause_flag.store(true, Ordering::Relaxed);
+                    PlayerAction::None
+                }
+                PlaybackState::Paused => {
+                    self.state = PlaybackState::Playing;
+                    self.pause_flag.store(false, Ordering::Relaxed);
+                    self.playback_start = Some(Instant::now());
+                    PlayerAction::None
+                }
+                PlaybackState::Stopped => {
+                    self.state = PlaybackState::Playing;
+                    PlayerAction::LoadAndPlay
+                }
+            },
+            PlayerCommand::Stop => {
+                self.state = PlaybackState::Stopped;
+                self.playback_position = Duration::ZERO;
+                self.pause_offset = Duration::ZERO;
+                self.stop_flag.store(true, Ordering::Relaxed);
+                PlayerAction::None
+            }
+            PlayerCommand::NextTrack => {
+                self.stop_flag.store(true, Ordering::Relaxed);
+                if self.current_index + 1 < self.tracks.len() {
+                    self.current_index += 1;
+                    PlayerAction::LoadAndPlay
+                } else {
+                    self.state = PlaybackState::Stopped;
+                    PlayerAction::None
+                }
+            }
+            PlayerCommand::PrevTrack => {
+                self.stop_flag.store(true, Ordering::Relaxed);
+                // If more than 3 seconds in, restart current track
+                if self.current_position().as_secs() > 3 || self.current_index == 0 {
+                    PlayerAction::LoadAndPlay
+                } else {
+                    self.current_index -= 1;
+                    PlayerAction::LoadAndPlay
+                }
+            }
+            PlayerCommand::SeekForward(_) | PlayerCommand::SeekBackward(_) => {
+                // Seeking requires re-decode — simplified for now
+                PlayerAction::None
+            }
+            PlayerCommand::VolumeUp => {
+                self.volume = Volume((self.volume.0 + 1.0).min(6.0));
+                PlayerAction::None
+            }
+            PlayerCommand::VolumeDown => {
+                self.volume = Volume((self.volume.0 - 1.0).max(-30.0));
+                PlayerAction::None
+            }
+            PlayerCommand::Quit => PlayerAction::Quit,
+        }
+    }
+
+    /// Get current playback position.
+    pub fn current_position(&self) -> Duration {
+        if self.state == PlaybackState::Playing
+            && let Some(start) = self.playback_start
+        {
+            return self.pause_offset + start.elapsed();
+        }
+        self.pause_offset
+    }
+
+    /// Get current track duration.
+    pub fn duration(&self) -> Duration {
+        self.current_duration
+    }
+
+    /// Get current state.
+    pub fn state(&self) -> PlaybackState {
+        self.state
+    }
+
+    /// Get current track (if any).
+    pub fn current_track(&self) -> Option<&Track> {
+        self.tracks.get(self.current_index)
+    }
+
+    /// Get current track index and total count.
+    pub fn queue_position(&self) -> (usize, usize) {
+        (self.current_index + 1, self.tracks.len())
+    }
+
+    /// Get current volume in dB.
+    pub fn volume_db(&self) -> f32 {
+        self.volume.0
+    }
+
+    /// Get EQ preset name (if any).
+    pub fn eq_preset_name(&self) -> Option<&str> {
+        self.eq_preset.map(|p| p.name)
+    }
+
+    /// Called when playback thread finishes naturally (track ended).
+    pub fn on_track_finished(&mut self) -> PlayerAction {
+        if self.state == PlaybackState::Playing && self.current_index + 1 < self.tracks.len() {
+            self.current_index += 1;
+            PlayerAction::LoadAndPlay
+        } else {
+            self.state = PlaybackState::Stopped;
+            PlayerAction::None
+        }
+    }
+
+    /// Set playback start time (called after thread spawn).
+    pub fn mark_playback_started(&mut self) {
+        self.playback_start = Some(Instant::now());
+    }
+
+    /// Get the track list for display.
+    pub fn tracks(&self) -> &[Track] {
+        &self.tracks
+    }
+
+    /// Get current track index (0-based).
+    pub fn current_index(&self) -> usize {
+        self.current_index
+    }
+}
+
+/// Action the TUI should take after handling a command.
+pub enum PlayerAction {
+    None,
+    LoadAndPlay,
+    Quit,
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,261 @@
+//! TUI application — ratatui event loop, rendering, and input handling.
+
+use std::io;
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::ExecutableCommand;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Gauge, List, ListItem, Paragraph};
+use ratatui::{DefaultTerminal, Frame};
+
+use crate::playback::player::{PlaybackState, Player, PlayerAction, PlayerCommand};
+
+/// Run the TUI application.
+pub fn run(mut player: Player) -> Result<()> {
+    // Load and start playing the first track
+    player.play_current()?;
+    let mut playback_handle = player.start_playback();
+    player.mark_playback_started();
+
+    // Enter alternate screen
+    io::stdout().execute(EnterAlternateScreen)?;
+    terminal::enable_raw_mode()?;
+
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal, &mut player, &mut playback_handle);
+
+    // Restore terminal
+    ratatui::restore();
+    io::stdout().execute(LeaveAlternateScreen)?;
+
+    result
+}
+
+fn run_loop(
+    terminal: &mut DefaultTerminal,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+) -> Result<()> {
+    let tick_rate = Duration::from_millis(100);
+
+    loop {
+        // Draw
+        terminal.draw(|frame| draw(frame, player))?;
+
+        // Check if playback thread finished (track ended naturally)
+        if let Some(handle) = playback_handle.as_ref()
+            && handle.is_finished()
+        {
+            if let Some(h) = playback_handle.take() {
+                let _ = h.join();
+            }
+            let action = player.on_track_finished();
+            handle_action(action, player, playback_handle)?;
+        }
+
+        // Poll for keyboard input
+        if event::poll(tick_rate)?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            let cmd = match key.code {
+                KeyCode::Char(' ') => Some(PlayerCommand::PlayPause),
+                KeyCode::Char('s') => Some(PlayerCommand::Stop),
+                KeyCode::Char('q') => Some(PlayerCommand::Quit),
+                KeyCode::Char('n') => Some(PlayerCommand::NextTrack),
+                KeyCode::Char('p') => Some(PlayerCommand::PrevTrack),
+                KeyCode::Right => Some(PlayerCommand::SeekForward(Duration::from_secs(5))),
+                KeyCode::Left => Some(PlayerCommand::SeekBackward(Duration::from_secs(5))),
+                KeyCode::Char('+') | KeyCode::Char('=') => Some(PlayerCommand::VolumeUp),
+                KeyCode::Char('-') => Some(PlayerCommand::VolumeDown),
+                _ => None,
+            };
+
+            if let Some(cmd) = cmd {
+                let action = player.handle_command(cmd);
+                if matches!(action, PlayerAction::Quit) {
+                    return Ok(());
+                }
+                handle_action(action, player, playback_handle)?;
+            }
+        }
+    }
+}
+
+fn handle_action(
+    action: PlayerAction,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+) -> Result<()> {
+    match action {
+        PlayerAction::None => {}
+        PlayerAction::LoadAndPlay => {
+            // Stop and join previous playback thread
+            if let Some(h) = playback_handle.take() {
+                let _ = h.join();
+            }
+            player.play_current()?;
+            *playback_handle = player.start_playback();
+            player.mark_playback_started();
+        }
+        PlayerAction::Quit => {}
+    }
+    Ok(())
+}
+
+fn draw(frame: &mut Frame, player: &Player) {
+    let area = frame.area();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5), // Track info + progress
+            Constraint::Min(3),    // Playlist
+            Constraint::Length(1), // Status bar
+        ])
+        .split(area);
+
+    draw_track_info(frame, chunks[0], player);
+    draw_playlist(frame, chunks[1], player);
+    draw_status_bar(frame, chunks[2], player);
+}
+
+fn draw_track_info(frame: &mut Frame, area: Rect, player: &Player) {
+    let block = Block::default().borders(Borders::ALL).title(" kora ");
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // Track name
+            Constraint::Length(1), // Progress bar
+            Constraint::Length(1), // Status line
+        ])
+        .split(inner);
+
+    // Track name
+    let (queue_pos, queue_total) = player.queue_position();
+    let track_name = player
+        .current_track()
+        .map(|t| t.display_name())
+        .unwrap_or_else(|| "No track".into());
+
+    let track_line = Line::from(vec![
+        Span::styled(
+            format!("[{queue_pos}/{queue_total}] "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            track_name,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(track_line), chunks[0]);
+
+    // Progress bar
+    let position = player.current_position();
+    let duration = player.duration();
+    let ratio = if duration.as_secs_f64() > 0.0 {
+        (position.as_secs_f64() / duration.as_secs_f64()).min(1.0)
+    } else {
+        0.0
+    };
+
+    let progress_label = format!(
+        "{} / {}",
+        format_duration(position),
+        format_duration(duration)
+    );
+
+    let gauge = Gauge::default()
+        .gauge_style(Style::default().fg(Color::Cyan).bg(Color::DarkGray))
+        .ratio(ratio)
+        .label(progress_label);
+    frame.render_widget(gauge, chunks[1]);
+
+    // Status line
+    let state_icon = match player.state() {
+        PlaybackState::Playing => "▶ Playing",
+        PlaybackState::Paused => "⏸ Paused",
+        PlaybackState::Stopped => "■ Stopped",
+    };
+
+    let eq_info = player
+        .eq_preset_name()
+        .map(|n| format!("  EQ: {n}"))
+        .unwrap_or_default();
+
+    let status = Line::from(vec![
+        Span::styled(state_icon, Style::default().fg(Color::Green)),
+        Span::styled(
+            format!("  Vol: {:+.0}dB{eq_info}", player.volume_db()),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(status), chunks[2]);
+}
+
+fn draw_playlist(frame: &mut Frame, area: Rect, player: &Player) {
+    let block = Block::default().borders(Borders::ALL).title(" Playlist ");
+
+    let items: Vec<ListItem> = player
+        .tracks()
+        .iter()
+        .enumerate()
+        .map(|(i, track)| {
+            let is_current = i == player.current_index();
+            let prefix = if is_current { "▶ " } else { "  " };
+            let style = if is_current {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{}. {}", i + 1, track.display_name()),
+                style,
+            )))
+        })
+        .collect();
+
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+fn draw_status_bar(frame: &mut Frame, area: Rect, _player: &Player) {
+    let help = Line::from(vec![
+        Span::styled("Spc", Style::default().fg(Color::Yellow)),
+        Span::raw(":Play/Pause "),
+        Span::styled("n/p", Style::default().fg(Color::Yellow)),
+        Span::raw(":Next/Prev "),
+        Span::styled("s", Style::default().fg(Color::Yellow)),
+        Span::raw(":Stop "),
+        Span::styled("+/-", Style::default().fg(Color::Yellow)),
+        Span::raw(":Vol "),
+        Span::styled("←/→", Style::default().fg(Color::Yellow)),
+        Span::raw(":Seek "),
+        Span::styled("q", Style::default().fg(Color::Yellow)),
+        Span::raw(":Quit"),
+    ]);
+    frame.render_widget(Paragraph::new(help), area);
+}
+
+fn format_duration(d: Duration) -> String {
+    let total_secs = d.as_secs();
+    let mins = total_secs / 60;
+    let secs = total_secs % 60;
+    format!("{mins}:{secs:02}")
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,1 @@
+pub mod app;


### PR DESCRIPTION
## Description

Add the TUI player, 10-band graphic equalizer, and pause/resume support — kora is now a usable terminal audio player.

### What's included

- **TUI**: ratatui-based interface with track info (title, queue position), progress bar with time display, transport status (▶ Playing / ⏸ Paused / ■ Stopped), playlist panel with current track highlighted, and a keybinding help bar
- **Keyboard controls**: Space (play/pause), n/p (next/prev track), +/- (volume), s (stop), q (quit), arrow keys (seek — mapped, not yet wired)
- **10-band graphic EQ**: Biquad IIR filters (Transposed Direct Form II) at 31Hz–16kHz with low-shelf/high-shelf on edge bands, Nyquist guard for low sample rates. 11 built-in presets: Flat, Rock, Pop, Jazz, Classical, Electronic, Hip Hop, Acoustic, Bass Boost, Treble Boost, Vocal
- **`--eq-preset` and `--list-eq-presets` CLI flags**
- **Pause/resume**: Uses an atomic pause flag so the playback thread stays alive — no re-decode on resume, instant response
- **Player controller**: New `playback/player.rs` decouples TUI from audio pipeline via a command pattern

## Related Issues

Closes #6, closes #7

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `playback/` — Decode, DSP, state machine
- [x] `backend/` — Audio output (CPAL)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (20 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)