### PR TITLE
feat: add live volume control and session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 10-band graphic equalizer with 11 presets (Flat, Rock, Pop, Jazz, Classical, Electronic, Hip Hop, Acoustic, Bass Boost, Treble Boost, Vocal)
 - `--eq-preset` CLI flag and `--list-eq-presets` to show available presets
 - Low-shelf filter at 31Hz and high-shelf at highest band for natural EQ response
+- Live volume adjustment: +/- keys take effect on currently playing audio immediately
+- Session persistence: auto-save on quit and every 30 seconds, restore on next launch (starts paused)
+- `--no-restore` CLI flag to skip session restore and start fresh
 
 ### Fixed
 

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -138,11 +138,15 @@ pub fn play_audio(
 }
 
 /// Play audio with position tracking and pause/resume support.
+///
+/// `volume` is a shared atomic storing the f32 linear gain as raw bits
+/// (`f32::to_bits()`). The producer reads it on each chunk, so volume
+/// changes from the Player take effect immediately — no track restart needed.
 pub fn play_audio_with_position(
     samples: &[f32],
     sample_rate: u32,
     channels: usize,
-    volume: f32,
+    volume: &Arc<AtomicU32>,
     stop: &Arc<AtomicBool>,
     pause: &Arc<AtomicBool>,
     samples_played: &AtomicU64,
@@ -194,10 +198,14 @@ pub fn play_audio_with_position(
             std::thread::sleep(std::time::Duration::from_millis(5));
             continue;
         }
+
+        // Read current volume once per chunk for live volume control
+        let vol = f32::from_bits(volume.load(Ordering::Relaxed));
+
         let chunk_end = (pos + slots).min(samples.len());
         let chunk = &samples[pos..chunk_end];
         for &s in chunk {
-            let _ = producer.push(s * volume);
+            let _ = producer.push(s * vol);
         }
         pos = chunk_end;
         samples_played.store(pos as u64, Ordering::Relaxed);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
+pub mod session;
 pub mod track;
 pub mod types;

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -1,0 +1,128 @@
+//! Session persistence — save and restore playback state across runs.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Persisted playback state saved between sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Session {
+    pub track_path: Option<String>,
+    pub position_ms: u64,
+    pub queue: Vec<String>,
+    pub queue_index: usize,
+    pub volume_db: f32,
+    pub eq_preset: Option<String>,
+}
+
+impl Session {
+    /// Serialize to TOML and write atomically (write to .tmp, then rename).
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create config directory: {}", parent.display())
+            })?;
+        }
+
+        let toml_str = toml::to_string_pretty(self).context("Failed to serialize session")?;
+
+        let tmp_path = path.with_extension("toml.tmp");
+        std::fs::write(&tmp_path, toml_str).with_context(|| {
+            format!("Failed to write temp session file: {}", tmp_path.display())
+        })?;
+
+        std::fs::rename(&tmp_path, path)
+            .with_context(|| format!("Failed to rename session file to: {}", path.display()))?;
+
+        Ok(())
+    }
+
+    /// Deserialize from TOML. Returns default session if file is missing.
+    pub fn load(path: &Path) -> Result<Session> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                let session: Session = toml::from_str(&contents)
+                    .with_context(|| format!("Failed to parse session file: {}", path.display()))?;
+                Ok(session)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Session::default()),
+            Err(e) => Err(anyhow::anyhow!(
+                "Failed to read session file {}: {}",
+                path.display(),
+                e
+            )),
+        }
+    }
+
+    /// Platform-appropriate path for the session file.
+    pub fn session_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("kora")
+            .join("session.toml")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_session")
+    }
+
+    #[test]
+    fn round_trip_save_load() {
+        let dir = test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("round_trip.toml");
+
+        let session = Session {
+            track_path: Some("C:/Music/song.mp3".to_string()),
+            position_ms: 142000,
+            queue: vec![
+                "C:/Music/song1.mp3".to_string(),
+                "C:/Music/song2.mp3".to_string(),
+            ],
+            queue_index: 1,
+            volume_db: -3.0,
+            eq_preset: Some("Rock".to_string()),
+        };
+
+        session.save(&path).unwrap();
+        let loaded = Session::load(&path).unwrap();
+        assert_eq!(session, loaded);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let path = test_dir().join("nonexistent.toml");
+        let session = Session::load(&path).unwrap();
+        assert_eq!(session, Session::default());
+    }
+
+    #[test]
+    fn load_corrupt_file_returns_error() {
+        let dir = test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("corrupt.toml");
+        std::fs::write(&path, "this is not valid {{{{").unwrap();
+
+        let result = Session::load(&path);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn session_path_is_valid() {
+        let path = Session::session_path();
+        assert!(path.ends_with("session.toml"));
+        assert!(path.to_string_lossy().contains("kora"));
+    }
+}

--- a/src/core/track.rs
+++ b/src/core/track.rs
@@ -33,6 +33,14 @@ impl Track {
         }
     }
 
+    /// Return the source path or URL as a string (for session persistence).
+    pub fn path_string(&self) -> String {
+        match &self.source {
+            TrackSource::File(p) => p.to_string_lossy().into_owned(),
+            TrackSource::Url(url) => url.clone(),
+        }
+    }
+
     pub fn display_name(&self) -> String {
         if let Some(ref meta) = self.metadata {
             if let (Some(artist), Some(title)) = (&meta.artist, &meta.title) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ struct Cli {
     /// List available EQ presets and exit
     #[arg(long)]
     list_eq_presets: bool,
+
+    /// Skip session restore (start fresh)
+    #[arg(long)]
+    no_restore: bool,
 }
 
 fn main() -> Result<()> {
@@ -80,7 +84,7 @@ fn main() -> Result<()> {
 
     // Launch TUI player
     let player = playback::player::Player::new(tracks, cli.volume, cli.eq_preset.as_deref())?;
-    tui::app::run(player)?;
+    tui::app::run(player, cli.no_restore)?;
 
     Ok(())
 }

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -6,12 +6,13 @@
 //! current track) without blocking the audio pipeline.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
 use crate::backend::cpal_backend;
+use crate::core::session::Session;
 use crate::core::track::{Track, TrackSource};
 use crate::core::types::Volume;
 use crate::playback::decoder;
@@ -65,6 +66,7 @@ pub struct Player {
 
     stop_flag: Arc<AtomicBool>,
     pause_flag: Arc<AtomicBool>,
+    shared_volume: Arc<AtomicU32>,
     position: Arc<SharedPosition>,
 }
 
@@ -81,6 +83,8 @@ impl Player {
             None => None,
         };
 
+        let initial_linear = Volume(volume_db).as_linear();
+
         Ok(Self {
             tracks,
             current_index: 0,
@@ -96,6 +100,7 @@ impl Player {
             pause_offset: Duration::ZERO,
             stop_flag: Arc::new(AtomicBool::new(false)),
             pause_flag: Arc::new(AtomicBool::new(false)),
+            shared_volume: Arc::new(AtomicU32::new(initial_linear.to_bits())),
             position: Arc::new(SharedPosition {
                 samples_played: AtomicU64::new(0),
                 total_samples: AtomicU64::new(0),
@@ -148,6 +153,10 @@ impl Player {
             .store(total_samples, Ordering::Relaxed);
         self.position.samples_played.store(0, Ordering::Relaxed);
 
+        // Sync shared volume so the producer thread picks up the current value
+        self.shared_volume
+            .store(self.volume.as_linear().to_bits(), Ordering::Relaxed);
+
         self.state = PlaybackState::Playing;
         self.playback_start = Some(Instant::now());
 
@@ -160,7 +169,7 @@ impl Player {
         let samples = self.current_samples.take()?;
         let sample_rate = self.current_sample_rate;
         let channels = self.current_channels;
-        let volume = self.volume.as_linear();
+        let volume = self.shared_volume.clone();
 
         // Reset flags for this playback session.
         self.stop_flag.store(false, Ordering::Relaxed);
@@ -174,7 +183,7 @@ impl Player {
                 &samples,
                 sample_rate,
                 channels,
-                volume,
+                &volume,
                 &stop,
                 &pause,
                 &position.samples_played,
@@ -238,10 +247,14 @@ impl Player {
             }
             PlayerCommand::VolumeUp => {
                 self.volume = Volume((self.volume.0 + 1.0).min(6.0));
+                self.shared_volume
+                    .store(self.volume.as_linear().to_bits(), Ordering::Relaxed);
                 PlayerAction::None
             }
             PlayerCommand::VolumeDown => {
                 self.volume = Volume((self.volume.0 - 1.0).max(-30.0));
+                self.shared_volume
+                    .store(self.volume.as_linear().to_bits(), Ordering::Relaxed);
                 PlayerAction::None
             }
             PlayerCommand::Quit => PlayerAction::Quit,
@@ -312,6 +325,48 @@ impl Player {
     /// Get current track index (0-based).
     pub fn current_index(&self) -> usize {
         self.current_index
+    }
+
+    /// Build a [`Session`] from current player state and save it to disk.
+    pub fn save_session(&self) -> Result<()> {
+        let session = Session {
+            track_path: self.current_track().map(|t| t.path_string()),
+            position_ms: self.current_position().as_millis() as u64,
+            queue: self.tracks.iter().map(|t| t.path_string()).collect(),
+            queue_index: self.current_index,
+            volume_db: self.volume.0,
+            eq_preset: self.eq_preset_name().map(|s| s.to_string()),
+        };
+        session.save(&Session::session_path())
+    }
+
+    /// Apply a saved session: match track by path, restore queue index,
+    /// volume, and EQ preset. Returns `true` if a matching track was found.
+    pub fn restore_session(&mut self, session: &Session) -> bool {
+        self.volume = Volume(session.volume_db);
+
+        if let Some(ref preset_name) = session.eq_preset {
+            if let Some(preset) = eq::find_preset(preset_name) {
+                self.eq_preset = Some(preset);
+            } else {
+                tracing::warn!("Saved EQ preset '{preset_name}' not found, ignoring");
+            }
+        }
+
+        if let Some(ref track_path) = session.track_path {
+            if let Some(idx) = self
+                .tracks
+                .iter()
+                .position(|t| t.path_string() == *track_path)
+            {
+                self.current_index = idx;
+                return true;
+            }
+            tracing::warn!(
+                "Saved track '{track_path}' not found in queue, starting from beginning"
+            );
+        }
+        false
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,7 @@
 //! TUI application — ratatui event loop, rendering, and input handling.
 
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::ExecutableCommand;
@@ -13,14 +13,37 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Gauge, List, ListItem, Paragraph};
 use ratatui::{DefaultTerminal, Frame};
 
+use crate::core::session::Session;
 use crate::playback::player::{PlaybackState, Player, PlayerAction, PlayerCommand};
 
 /// Run the TUI application.
-pub fn run(mut player: Player) -> Result<()> {
-    // Load and start playing the first track
+pub fn run(mut player: Player, no_restore: bool) -> Result<()> {
+    // Session restore
+    let mut restored = false;
+    if !no_restore {
+        let session_path = Session::session_path();
+        match Session::load(&session_path) {
+            Ok(session) if session.track_path.is_some() => {
+                let found = player.restore_session(&session);
+                if found {
+                    tracing::info!("Session restored");
+                    restored = true;
+                }
+            }
+            Ok(_) => {} // empty/default session
+            Err(e) => tracing::warn!("Failed to load session: {e}"),
+        }
+    }
+
+    // Load and start playing the current track
     player.play_current()?;
     let mut playback_handle = player.start_playback();
     player.mark_playback_started();
+
+    // If we restored a session, start paused so the user can resume manually
+    if restored {
+        let _ = player.handle_command(PlayerCommand::PlayPause);
+    }
 
     // Enter alternate screen
     io::stdout().execute(EnterAlternateScreen)?;
@@ -42,6 +65,8 @@ fn run_loop(
     playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
 ) -> Result<()> {
     let tick_rate = Duration::from_millis(100);
+    let save_interval = Duration::from_secs(30);
+    let mut last_save = Instant::now();
 
     loop {
         // Draw
@@ -56,6 +81,14 @@ fn run_loop(
             }
             let action = player.on_track_finished();
             handle_action(action, player, playback_handle)?;
+        }
+
+        // Auto-save session every 30 seconds
+        if last_save.elapsed() >= save_interval {
+            if let Err(e) = player.save_session() {
+                tracing::warn!("Failed to auto-save session: {e}");
+            }
+            last_save = Instant::now();
         }
 
         // Poll for keyboard input
@@ -82,6 +115,10 @@ fn run_loop(
             if let Some(cmd) = cmd {
                 let action = player.handle_command(cmd);
                 if matches!(action, PlayerAction::Quit) {
+                    // Save session before quitting
+                    if let Err(e) = player.save_session() {
+                        tracing::warn!("Failed to save session on quit: {e}");
+                    }
                     return Ok(());
                 }
                 handle_action(action, player, playback_handle)?;


### PR DESCRIPTION
## Description

Add live volume control and session persistence so the player remembers where you left off.

### What's included

- **Live volume adjustment**: +/- keys now affect currently playing audio immediately via a lock-free atomic shared between the player and the producer thread — no restart or re-decode needed
- **Session persistence**: Playback state (track, position, queue, volume, EQ preset) is saved to `session.toml` on quit and every 30 seconds. On next launch, kora restores state and starts paused so you can resume with Space
- **`--no-restore` CLI flag**: Skip session restore when you want a fresh start

## Related Issues

Closes #8, closes #9

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `core/` — Domain models, traits, config
- [x] `playback/` — Decode, DSP, state machine
- [x] `backend/` — Audio output (CPAL)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (24 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)