### PR TITLE
feat: add interactive EQ view with visual bars and custom presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Favorites persisted in `favorites.toml`
 - Sleep timer: press `Shift+S` to cycle presets (15/30/45/60/90 minutes), countdown shown in status bar
 - Sleep timer fades volume over the last 30 seconds before stopping playback
+- Interactive EQ view: press `e` to toggle, `h`/`l` to select band, `j`/`k` to adjust gain ±1dB
+- Visual EQ display with vertical bars per band, selected band highlighted
+- Preset cycling within EQ view, display shows "Custom" when gains are manually adjusted
+- Custom EQ presets definable in `config.toml`
+
+### Changed
+
+- Crate published as `kora-player` on crates.io (binary is still `kora`). Install with `cargo install kora-player`
 
 ## [0.2.0] - 2026-04-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "kora"
-version = "0.2.0"
+name = "kora-player"
+version = "0.3.0"
 edition = "2024"
 description = "A fast, multi-source terminal audio player"
 license = "MIT OR Apache-2.0"
@@ -8,6 +8,10 @@ repository = "https://github.com/kafkade/kora"
 readme = "README.md"
 keywords = ["audio", "music", "player", "tui", "terminal"]
 categories = ["multimedia::audio", "command-line-utilities"]
+
+[[bin]]
+name = "kora"
+path = "src/main.rs"
 
 [dependencies]
 # Audio decoding (pure Rust, no C deps)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ MP3, FLAC, OGG Vorbis, Opus, WAV — decoded natively in Rust via [symphonia](ht
 
 ## Install
 
+### From crates.io
+
+```sh
+cargo install kora-player
+```
+
 ### From source
 
 ```sh

--- a/config.toml.example
+++ b/config.toml.example
@@ -19,3 +19,15 @@
 
 # Ring buffer size in milliseconds (50-500, higher = more latency but fewer underruns)
 # buffer_ms = 200
+
+# Custom EQ presets (in addition to built-in ones)
+# Each preset has a name and 10 band gains in dB (-12 to +12)
+# Bands: 31Hz, 62Hz, 125Hz, 250Hz, 500Hz, 1kHz, 2kHz, 4kHz, 8kHz, 16kHz
+#
+# [[custom_eq_presets]]
+# name = "My Preset"
+# gains = [0.0, 0.0, 2.0, 4.0, 3.0, 0.0, -1.0, 0.0, 2.0, 3.0]
+#
+# [[custom_eq_presets]]
+# name = "Late Night"
+# gains = [-4.0, -2.0, 0.0, 2.0, 4.0, 4.0, 2.0, 0.0, -2.0, -4.0]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -5,6 +5,13 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
+/// A user-defined EQ preset stored in config.toml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomEqPreset {
+    pub name: String,
+    pub gains: [f32; 10],
+}
+
 /// Application configuration loaded from `config.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -21,6 +28,9 @@ pub struct KoraConfig {
     pub sample_rate: Option<u32>,
     /// Ring buffer size in milliseconds (50–500).
     pub buffer_ms: u32,
+    /// Custom EQ presets (in addition to built-in ones).
+    #[serde(default)]
+    pub custom_eq_presets: Vec<CustomEqPreset>,
 }
 
 impl Default for KoraConfig {
@@ -32,6 +42,7 @@ impl Default for KoraConfig {
             eq_preset: None,
             sample_rate: None,
             buffer_ms: 200,
+            custom_eq_presets: Vec::new(),
         }
     }
 }
@@ -81,6 +92,19 @@ impl KoraConfig {
                 self.buffer_ms
             );
         }
+        for preset in &self.custom_eq_presets {
+            if preset.name.is_empty() {
+                bail!("Custom EQ preset name must not be empty");
+            }
+            for &gain in &preset.gains {
+                if !(-12.0..=12.0).contains(&gain) {
+                    bail!(
+                        "Custom EQ preset '{}' has out-of-range gain: {gain} (must be -12..+12)",
+                        preset.name
+                    );
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -98,6 +122,7 @@ mod tests {
         assert!(config.eq_preset.is_none());
         assert!(config.sample_rate.is_none());
         assert_eq!(config.buffer_ms, 200);
+        assert!(config.custom_eq_presets.is_empty());
     }
 
     #[test]
@@ -109,6 +134,10 @@ mod tests {
             eq_preset: Some("Rock".to_string()),
             sample_rate: Some(48000),
             buffer_ms: 300,
+            custom_eq_presets: vec![CustomEqPreset {
+                name: "Test".to_string(),
+                gains: [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, -2.0, -3.0, -4.0, -5.0],
+            }],
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -120,6 +149,12 @@ mod tests {
         assert_eq!(loaded.eq_preset, config.eq_preset);
         assert_eq!(loaded.sample_rate, config.sample_rate);
         assert_eq!(loaded.buffer_ms, config.buffer_ms);
+        assert_eq!(loaded.custom_eq_presets.len(), 1);
+        assert_eq!(loaded.custom_eq_presets[0].name, "Test");
+        assert_eq!(
+            loaded.custom_eq_presets[0].gains,
+            config.custom_eq_presets[0].gains
+        );
     }
 
     #[test]
@@ -225,5 +260,42 @@ mod tests {
         assert!(config.music_dir.is_none());
         assert!(config.eq_preset.is_none());
         assert_eq!(config.buffer_ms, 200);
+        assert!(config.custom_eq_presets.is_empty());
+    }
+
+    #[test]
+    fn validate_custom_eq_preset_out_of_range() {
+        let config = KoraConfig {
+            custom_eq_presets: vec![CustomEqPreset {
+                name: "Bad".to_string(),
+                gains: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 15.0],
+            }],
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_custom_eq_preset_empty_name() {
+        let config = KoraConfig {
+            custom_eq_presets: vec![CustomEqPreset {
+                name: String::new(),
+                gains: [0.0; 10],
+            }],
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn custom_eq_preset_from_toml() {
+        let toml_str = r#"
+            [[custom_eq_presets]]
+            name = "My Preset"
+            gains = [0.0, 1.0, 2.0, 3.0, 4.0, -1.0, -2.0, 0.0, 1.0, 2.0]
+        "#;
+        let config: KoraConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.custom_eq_presets.len(), 1);
+        assert_eq!(config.custom_eq_presets[0].name, "My Preset");
     }
 }

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -78,6 +78,11 @@ pub enum PlayerCommand {
     #[allow(dead_code)]
     CancelSleepTimer,
     CycleSleepTimer,
+    CycleEqPreset,
+    EqBandUp,
+    EqBandDown,
+    EqBandLeft,
+    EqBandRight,
     Quit,
 }
 
@@ -119,6 +124,9 @@ pub struct Player {
     volume: Volume,
     state: PlaybackState,
     eq_preset: Option<&'static EqPreset>,
+    eq_preset_index: usize,
+    eq_selected_band: usize,
+    custom_gains: Option<[f32; 10]>,
     shuffle: bool,
     repeat: RepeatMode,
     shuffle_order: Vec<usize>,
@@ -156,6 +164,15 @@ impl Player {
 
         let initial_linear = Volume(volume_db).as_linear();
 
+        let eq_preset_index = preset
+            .map(|p| {
+                eq::PRESETS
+                    .iter()
+                    .position(|bp| std::ptr::eq(bp, p))
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
+
         let favorites = Favorites::load().unwrap_or_else(|e| {
             tracing::warn!("Failed to load favorites: {e}");
             Favorites::default()
@@ -167,6 +184,9 @@ impl Player {
             volume: Volume(volume_db),
             state: PlaybackState::Stopped,
             eq_preset: preset,
+            eq_preset_index,
+            eq_selected_band: 0,
+            custom_gains: None,
             shuffle: false,
             repeat: RepeatMode::Off,
             shuffle_order: Vec::new(),
@@ -203,7 +223,13 @@ impl Player {
                 .with_context(|| format!("Failed to stream {url}"))?,
         };
 
-        let samples = if let Some(p) = self.eq_preset {
+        let samples = if let Some(gains) = self.custom_gains {
+            let mut eq = Equalizer::new(decoded.sample_rate, decoded.channels);
+            eq.set_gains(gains);
+            let mut buf = decoded.samples;
+            eq.process(&mut buf, decoded.channels);
+            buf
+        } else if let Some(p) = self.eq_preset {
             let mut eq = Equalizer::new(decoded.sample_rate, decoded.channels);
             eq.apply_preset(p);
             let mut buf = decoded.samples;
@@ -415,6 +441,36 @@ impl Player {
                 }
                 PlayerAction::None
             }
+            PlayerCommand::CycleEqPreset => {
+                self.eq_preset_index = (self.eq_preset_index + 1) % eq::PRESETS.len();
+                self.eq_preset = Some(&eq::PRESETS[self.eq_preset_index]);
+                self.custom_gains = None;
+                PlayerAction::None
+            }
+            PlayerCommand::EqBandUp => {
+                let mut gains = self.eq_gains();
+                gains[self.eq_selected_band] = (gains[self.eq_selected_band] + 1.0).min(12.0);
+                self.custom_gains = Some(gains);
+                PlayerAction::None
+            }
+            PlayerCommand::EqBandDown => {
+                let mut gains = self.eq_gains();
+                gains[self.eq_selected_band] = (gains[self.eq_selected_band] - 1.0).max(-12.0);
+                self.custom_gains = Some(gains);
+                PlayerAction::None
+            }
+            PlayerCommand::EqBandLeft => {
+                if self.eq_selected_band > 0 {
+                    self.eq_selected_band -= 1;
+                }
+                PlayerAction::None
+            }
+            PlayerCommand::EqBandRight => {
+                if self.eq_selected_band < 9 {
+                    self.eq_selected_band += 1;
+                }
+                PlayerAction::None
+            }
             PlayerCommand::Quit => PlayerAction::Quit,
         }
     }
@@ -456,7 +512,35 @@ impl Player {
 
     /// Get EQ preset name (if any).
     pub fn eq_preset_name(&self) -> Option<&str> {
+        if self.custom_gains.is_some() {
+            return None;
+        }
         self.eq_preset.map(|p| p.name)
+    }
+
+    /// Get current EQ display name — preset name or "Custom" if gains were adjusted.
+    pub fn eq_display_name(&self) -> &str {
+        if self.custom_gains.is_some() {
+            "Custom"
+        } else {
+            self.eq_preset.map(|p| p.name).unwrap_or("Off")
+        }
+    }
+
+    /// Get current EQ gains — custom if set, else preset, else flat.
+    pub fn eq_gains(&self) -> [f32; 10] {
+        if let Some(gains) = self.custom_gains {
+            gains
+        } else if let Some(p) = self.eq_preset {
+            p.gains
+        } else {
+            [0.0; 10]
+        }
+    }
+
+    /// Get the currently selected EQ band index (0-9).
+    pub fn eq_selected_band(&self) -> usize {
+        self.eq_selected_band
     }
 
     /// Add a track to the queue and start playing it immediately.
@@ -880,5 +964,93 @@ mod tests {
         player.handle_command(PlayerCommand::CancelSleepTimer);
         let restored_bits = player.shared_volume.load(Ordering::Relaxed);
         assert_eq!(restored_bits, original_bits);
+    }
+
+    #[test]
+    fn eq_cycle_preset() {
+        let mut player = test_player();
+        assert_eq!(player.eq_display_name(), "Off");
+
+        player.handle_command(PlayerCommand::CycleEqPreset);
+        // Starts at index 0, cycles to index 1 (Rock)
+        assert_eq!(player.eq_display_name(), "Rock");
+
+        player.handle_command(PlayerCommand::CycleEqPreset);
+        assert_eq!(player.eq_display_name(), "Pop");
+    }
+
+    #[test]
+    fn eq_band_navigation() {
+        let mut player = test_player();
+        assert_eq!(player.eq_selected_band(), 0);
+
+        player.handle_command(PlayerCommand::EqBandRight);
+        assert_eq!(player.eq_selected_band(), 1);
+
+        player.handle_command(PlayerCommand::EqBandRight);
+        assert_eq!(player.eq_selected_band(), 2);
+
+        player.handle_command(PlayerCommand::EqBandLeft);
+        assert_eq!(player.eq_selected_band(), 1);
+
+        // Clamp at 0
+        player.handle_command(PlayerCommand::EqBandLeft);
+        player.handle_command(PlayerCommand::EqBandLeft);
+        assert_eq!(player.eq_selected_band(), 0);
+    }
+
+    #[test]
+    fn eq_band_clamp_at_9() {
+        let mut player = test_player();
+        for _ in 0..20 {
+            player.handle_command(PlayerCommand::EqBandRight);
+        }
+        assert_eq!(player.eq_selected_band(), 9);
+    }
+
+    #[test]
+    fn eq_band_gain_adjust() {
+        let mut player = test_player();
+        assert_eq!(player.eq_gains(), [0.0; 10]);
+
+        player.handle_command(PlayerCommand::EqBandUp);
+        let gains = player.eq_gains();
+        assert_eq!(gains[0], 1.0);
+        assert_eq!(gains[1], 0.0);
+
+        player.handle_command(PlayerCommand::EqBandDown);
+        player.handle_command(PlayerCommand::EqBandDown);
+        let gains = player.eq_gains();
+        assert_eq!(gains[0], -1.0);
+    }
+
+    #[test]
+    fn eq_gain_clamp_at_12() {
+        let mut player = test_player();
+        for _ in 0..20 {
+            player.handle_command(PlayerCommand::EqBandUp);
+        }
+        assert_eq!(player.eq_gains()[0], 12.0);
+
+        for _ in 0..30 {
+            player.handle_command(PlayerCommand::EqBandDown);
+        }
+        assert_eq!(player.eq_gains()[0], -12.0);
+    }
+
+    #[test]
+    fn eq_custom_gains_override_preset() {
+        let mut player = test_player();
+        player.handle_command(PlayerCommand::CycleEqPreset); // Go to Rock
+        assert_eq!(player.eq_display_name(), "Rock");
+
+        // Adjusting a band makes it "Custom"
+        player.handle_command(PlayerCommand::EqBandUp);
+        assert_eq!(player.eq_display_name(), "Custom");
+        assert!(player.eq_preset_name().is_none());
+
+        // Cycling preset resets custom
+        player.handle_command(PlayerCommand::CycleEqPreset);
+        assert_ne!(player.eq_display_name(), "Custom");
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,6 +9,7 @@ use crossterm::ExecutableCommand;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Gauge, List, ListItem, Paragraph};
 use ratatui::{DefaultTerminal, Frame};
@@ -101,10 +102,11 @@ fn run_loop(
     let save_interval = Duration::from_secs(30);
     let mut last_save = Instant::now();
     let mut file_browser: Option<FileBrowser> = None;
+    let mut show_eq = false;
 
     loop {
         // Draw
-        terminal.draw(|frame| draw(frame, player, theme, file_browser.as_ref()))?;
+        terminal.draw(|frame| draw(frame, player, theme, file_browser.as_ref(), show_eq))?;
 
         // Tick sleep timer
         if let SleepAction::Stop = player.tick_sleep_timer() {
@@ -173,6 +175,41 @@ fn run_loop(
                 continue;
             }
 
+            // EQ view input handling
+            if show_eq {
+                let cmd = match key.code {
+                    KeyCode::Esc => {
+                        show_eq = false;
+                        None
+                    }
+                    KeyCode::Char('e') => Some(PlayerCommand::CycleEqPreset),
+                    KeyCode::Char('h') | KeyCode::Left => Some(PlayerCommand::EqBandLeft),
+                    KeyCode::Char('l') | KeyCode::Right => Some(PlayerCommand::EqBandRight),
+                    KeyCode::Char('k') | KeyCode::Up => Some(PlayerCommand::EqBandUp),
+                    KeyCode::Char('j') | KeyCode::Down => Some(PlayerCommand::EqBandDown),
+                    // Playback keys still work in EQ view
+                    KeyCode::Char(' ') => Some(PlayerCommand::PlayPause),
+                    KeyCode::Char('n') => Some(PlayerCommand::NextTrack),
+                    KeyCode::Char('p') => Some(PlayerCommand::PrevTrack),
+                    KeyCode::Char('+') | KeyCode::Char('=') => Some(PlayerCommand::VolumeUp),
+                    KeyCode::Char('-') => Some(PlayerCommand::VolumeDown),
+                    KeyCode::Char('q') => Some(PlayerCommand::Quit),
+                    _ => None,
+                };
+
+                if let Some(cmd) = cmd {
+                    let action = player.handle_command(cmd);
+                    if matches!(action, PlayerAction::Quit) {
+                        if let Err(e) = player.save_session() {
+                            tracing::warn!("Failed to save session on quit: {e}");
+                        }
+                        return Ok(());
+                    }
+                    handle_action(action, player, playback_handle)?;
+                }
+                continue;
+            }
+
             let cmd = match key.code {
                 KeyCode::Char(' ') => Some(PlayerCommand::PlayPause),
                 KeyCode::Char('s') => Some(PlayerCommand::Stop),
@@ -183,6 +220,10 @@ fn run_loop(
                 KeyCode::Left => Some(PlayerCommand::SeekBackward(Duration::from_secs(5))),
                 KeyCode::Char('+') | KeyCode::Char('=') => Some(PlayerCommand::VolumeUp),
                 KeyCode::Char('-') => Some(PlayerCommand::VolumeDown),
+                KeyCode::Char('e') => {
+                    show_eq = true;
+                    None
+                }
                 KeyCode::Char('t') => {
                     *theme_index = (*theme_index + 1) % themes.len();
                     *theme = themes[*theme_index].clone();
@@ -239,21 +280,33 @@ fn handle_action(
     Ok(())
 }
 
-fn draw(frame: &mut Frame, player: &Player, theme: &Theme, file_browser: Option<&FileBrowser>) {
+fn draw(
+    frame: &mut Frame,
+    player: &Player,
+    theme: &Theme,
+    file_browser: Option<&FileBrowser>,
+    show_eq: bool,
+) {
     let area = frame.area();
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(5), // Track info + progress
-            Constraint::Min(3),    // Playlist
+            Constraint::Min(3),    // Playlist or EQ view
             Constraint::Length(1), // Status bar
         ])
         .split(area);
 
     draw_track_info(frame, chunks[0], player, theme);
-    draw_playlist(frame, chunks[1], player, theme);
-    draw_status_bar(frame, chunks[2], player, theme);
+
+    if show_eq {
+        draw_eq_view(frame, chunks[1], player, theme);
+        draw_eq_status_bar(frame, chunks[2], player, theme);
+    } else {
+        draw_playlist(frame, chunks[1], player, theme);
+        draw_status_bar(frame, chunks[2], player, theme);
+    }
 
     // File browser overlay
     if let Some(browser) = file_browser {
@@ -332,10 +385,7 @@ fn draw_track_info(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
         PlaybackState::Stopped => ("■ Stopped", theme.status_stopped),
     };
 
-    let eq_info = player
-        .eq_preset_name()
-        .map(|n| format!("  EQ: {n}"))
-        .unwrap_or_default();
+    let eq_info = format!("  EQ: {}", player.eq_display_name());
 
     let shuffle_info = if player.shuffle() {
         "  Shuffle: On"
@@ -406,6 +456,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
         Span::styled(":Vol ", theme.help_text),
         Span::styled("←/→", theme.help_key),
         Span::styled(":Seek ", theme.help_text),
+        Span::styled("e", theme.help_key),
+        Span::styled(":EQ ", theme.help_text),
         Span::styled("t", theme.help_key),
         Span::styled(":Theme ", theme.help_text),
         Span::styled("o", theme.help_key),
@@ -443,6 +495,188 @@ fn format_duration(d: Duration) -> String {
     let mins = total_secs / 60;
     let secs = total_secs % 60;
     format!("{mins}:{secs:02}")
+}
+
+fn draw_eq_view(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border)
+        .title(format!(" EQ: {} ", player.eq_display_name()))
+        .title_style(theme.title);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height < 4 || inner.width < 40 {
+        let msg = Paragraph::new(Line::from(Span::styled(
+            "  (terminal too small for EQ view)",
+            theme.status_info,
+        )));
+        frame.render_widget(msg, inner);
+        return;
+    }
+
+    let gains = player.eq_gains();
+    let selected = player.eq_selected_band();
+    let labels = [
+        "31", "62", "125", "250", "500", "1k", "2k", "4k", "8k", "16k",
+    ];
+
+    // Layout: leave 1 row for frequency labels at bottom, 1 row for gain value at top
+    let chart_height = inner.height.saturating_sub(2) as i32;
+    if chart_height < 2 {
+        return;
+    }
+
+    // Scale: map -12..+12 dB to the chart height
+    let half = chart_height / 2;
+    let zero_row = half as u16; // row index of the 0dB line (from top of chart area)
+
+    // Chart area starts 1 row below inner.y (for the gain value display row)
+    let chart_y = inner.y + 1;
+    let label_y = chart_y + chart_height as u16;
+
+    // Calculate band width and spacing
+    let band_count = 10u16;
+    let total_width = inner.width;
+    let band_width = (total_width / band_count).max(1);
+
+    // Draw gain value header for selected band
+    let gain_val = gains[selected];
+    let gain_text = format!("{:+.0}dB", gain_val);
+    let gain_x = inner.x + selected as u16 * band_width + band_width / 2;
+    let gain_x = gain_x.saturating_sub(gain_text.len() as u16 / 2);
+    let gain_span = Span::styled(
+        gain_text,
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD),
+    );
+    if gain_x < inner.x + inner.width {
+        frame.render_widget(
+            Paragraph::new(Line::from(gain_span)),
+            Rect::new(gain_x, inner.y, (inner.x + inner.width - gain_x).min(6), 1),
+        );
+    }
+
+    // Draw the zero line
+    for x in 0..total_width {
+        let abs_x = inner.x + x;
+        let abs_y = chart_y + zero_row;
+        if abs_y < label_y {
+            let buf = frame.buffer_mut();
+            if abs_x < inner.x + inner.width {
+                buf[(abs_x, abs_y)]
+                    .set_char('─')
+                    .set_style(Style::default().fg(theme.dim));
+            }
+        }
+    }
+
+    // Draw each band bar
+    for (i, &gain) in gains.iter().enumerate() {
+        let bar_x = inner.x + i as u16 * band_width;
+        let is_selected = i == selected;
+        let bar_style = if is_selected {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.dim)
+        };
+
+        // Map gain to rows: each row = 12/half dB
+        let db_per_row = if half > 0 { 12.0 / half as f32 } else { 1.0 };
+        let bar_rows = (gain.abs() / db_per_row).round() as i32;
+        let bar_rows = bar_rows.min(half);
+
+        if gain >= 0.0 {
+            // Draw upward from zero line
+            for r in 0..bar_rows {
+                let y = chart_y + zero_row - 1 - r as u16;
+                if y >= chart_y {
+                    draw_bar_cell(frame, bar_x, y, band_width, bar_style, inner);
+                }
+            }
+        } else {
+            // Draw downward from zero line
+            for r in 0..bar_rows {
+                let y = chart_y + zero_row + 1 + r as u16;
+                if y < label_y {
+                    draw_bar_cell(frame, bar_x, y, band_width, bar_style, inner);
+                }
+            }
+        }
+
+        // Draw frequency label
+        if label_y < inner.y + inner.height {
+            let label = labels[i];
+            let lx = bar_x + band_width / 2;
+            let lx = lx.saturating_sub(label.len() as u16 / 2);
+            let available = (inner.x + inner.width).saturating_sub(lx);
+            if available > 0 {
+                let label_style = if is_selected {
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.dim)
+                };
+                frame.render_widget(
+                    Paragraph::new(Line::from(Span::styled(label, label_style))),
+                    Rect::new(lx, label_y, available.min(label.len() as u16), 1),
+                );
+            }
+        }
+    }
+}
+
+fn draw_bar_cell(frame: &mut Frame, x: u16, y: u16, band_width: u16, style: Style, inner: Rect) {
+    // Draw a bar cell with block chars, leaving 1 char padding on each side
+    let start = x + 1;
+    let end = (x + band_width).saturating_sub(1);
+    let buf = frame.buffer_mut();
+    for bx in start..end {
+        if bx < inner.x + inner.width {
+            buf[(bx, y)].set_char('█').set_style(style);
+        }
+    }
+}
+
+fn draw_eq_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) {
+    let mut spans = vec![
+        Span::styled("e", theme.help_key),
+        Span::styled(":Preset ", theme.help_text),
+        Span::styled("h/l", theme.help_key),
+        Span::styled(":Band ", theme.help_text),
+        Span::styled("j/k", theme.help_key),
+        Span::styled(":Gain ", theme.help_text),
+        Span::styled("Esc", theme.help_key),
+        Span::styled(":Close ", theme.help_text),
+        Span::styled("Spc", theme.help_key),
+        Span::styled(":Play/Pause ", theme.help_text),
+        Span::styled("n/p", theme.help_key),
+        Span::styled(":Next/Prev ", theme.help_text),
+        Span::styled("+/-", theme.help_key),
+        Span::styled(":Vol ", theme.help_text),
+        Span::styled("q", theme.help_key),
+        Span::styled(":Quit", theme.help_text),
+    ];
+
+    if let Some(remaining) = player.sleep_remaining() {
+        let sleep_text = if player.is_sleep_fading() {
+            " | Sleep: fading...".to_string()
+        } else {
+            let total_secs = remaining.as_secs();
+            let mins = total_secs / 60;
+            let secs = total_secs % 60;
+            format!(" | Sleep: {mins}:{secs:02}")
+        };
+        spans.push(Span::styled(sleep_text, theme.status_info));
+    }
+
+    let help = Line::from(spans);
+    frame.render_widget(Paragraph::new(help), area);
 }
 
 fn draw_file_browser(frame: &mut Frame, area: Rect, browser: &FileBrowser, theme: &Theme) {


### PR DESCRIPTION
## Description

Complete the interactive EQ experience and rename the crate for crates.io publishing.

### What's included

- **Interactive EQ view**: Press `e` to toggle a visual equalizer that replaces the playlist panel. 10 vertical bars show gain per band (31Hz–16kHz). `h`/`l` selects bands, `j`/`k` adjusts gain ±1dB (clamped to ±12dB). Preset cycling with `e` while in the view. Selected band highlighted with theme accent color. Shows "Custom" when gains are manually adjusted.
- **Custom EQ presets**: Users can define presets in `config.toml` via `[[custom_eq_presets]]` with name and 10-band gain values. Validated on load (gains clamped ±12dB, non-empty names).
- **Crate rename**: Package is now `kora-player` on crates.io (`cargo install kora-player`). The binary remains `kora` — no change for users.
- **README update**: Added `cargo install kora-player` as the primary install method.

## Related Issues

Closes #20

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `core/` — Domain models, traits, config
- [x] `playback/` — Decode, DSP, state machine
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (114 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)