### PR TITLE
feat: add playback speed control and ReplayGain normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Visualizer uses FFT with Hanning window, log-frequency binning, and smoothing for natural motion
 - Gapless playback: next track pre-decoded at 80% progress, seamless ring buffer transition with no audible gap
 - Gapless works across same-format tracks; falls back gracefully on sample rate or channel mismatch
+- Playback speed control: press `]`/`[` to adjust ±0.25x (range 0.25x–3.0x), speed shown in status bar
+- ReplayGain volume normalization: reads tags from ID3v2, Vorbis Comments, and MP4 files
+- ReplayGain applies track gain by default, album gain as option, configurable via `replaygain` in `config.toml`
+- ReplayGain info displayed in TUI status bar when active
 
 ### Changed
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -20,6 +20,11 @@
 # Ring buffer size in milliseconds (50-500, higher = more latency but fewer underruns)
 # buffer_ms = 200
 
+# ReplayGain mode: "off", "track" (default), or "album"
+# "track" normalizes each track individually
+# "album" preserves relative loudness within albums
+# replaygain = "track"
+
 # Custom EQ presets (in addition to built-in ones)
 # Each preset has a name and 10 band gains in dB (-12 to +12)
 # Bands: 31Hz, 62Hz, 125Hz, 250Hz, 500Hz, 1kHz, 2kHz, 4kHz, 8kHz, 16kHz

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -28,6 +28,8 @@ pub struct KoraConfig {
     pub sample_rate: Option<u32>,
     /// Ring buffer size in milliseconds (50–500).
     pub buffer_ms: u32,
+    /// ReplayGain mode: "off", "track" (default), or "album".
+    pub replaygain: String,
     /// Custom EQ presets (in addition to built-in ones).
     #[serde(default)]
     pub custom_eq_presets: Vec<CustomEqPreset>,
@@ -42,6 +44,7 @@ impl Default for KoraConfig {
             eq_preset: None,
             sample_rate: None,
             buffer_ms: 200,
+            replaygain: "track".to_string(),
             custom_eq_presets: Vec::new(),
         }
     }
@@ -92,6 +95,12 @@ impl KoraConfig {
                 self.buffer_ms
             );
         }
+        if !["off", "track", "album"].contains(&self.replaygain.to_ascii_lowercase().as_str()) {
+            bail!(
+                "replaygain must be \"off\", \"track\", or \"album\", got \"{}\"",
+                self.replaygain
+            );
+        }
         for preset in &self.custom_eq_presets {
             if preset.name.is_empty() {
                 bail!("Custom EQ preset name must not be empty");
@@ -122,6 +131,7 @@ mod tests {
         assert!(config.eq_preset.is_none());
         assert!(config.sample_rate.is_none());
         assert_eq!(config.buffer_ms, 200);
+        assert_eq!(config.replaygain, "track");
         assert!(config.custom_eq_presets.is_empty());
     }
 
@@ -134,6 +144,7 @@ mod tests {
             eq_preset: Some("Rock".to_string()),
             sample_rate: Some(48000),
             buffer_ms: 300,
+            replaygain: "album".to_string(),
             custom_eq_presets: vec![CustomEqPreset {
                 name: "Test".to_string(),
                 gains: [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, -2.0, -3.0, -4.0, -5.0],
@@ -149,6 +160,7 @@ mod tests {
         assert_eq!(loaded.eq_preset, config.eq_preset);
         assert_eq!(loaded.sample_rate, config.sample_rate);
         assert_eq!(loaded.buffer_ms, config.buffer_ms);
+        assert_eq!(loaded.replaygain, config.replaygain);
         assert_eq!(loaded.custom_eq_presets.len(), 1);
         assert_eq!(loaded.custom_eq_presets[0].name, "Test");
         assert_eq!(

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 /// Persisted playback state saved between sessions.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Session {
     pub track_path: Option<String>,
     pub position_ms: u64,
@@ -18,6 +18,28 @@ pub struct Session {
     pub shuffle: bool,
     #[serde(default)]
     pub repeat: String,
+    #[serde(default = "default_speed")]
+    pub speed: f32,
+}
+
+fn default_speed() -> f32 {
+    1.0
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self {
+            track_path: None,
+            position_ms: 0,
+            queue: Vec::new(),
+            queue_index: 0,
+            volume_db: 0.0,
+            eq_preset: None,
+            shuffle: false,
+            repeat: String::new(),
+            speed: default_speed(),
+        }
+    }
 }
 
 impl Session {
@@ -96,6 +118,7 @@ mod tests {
             eq_preset: Some("Rock".to_string()),
             shuffle: true,
             repeat: "All".to_string(),
+            speed: 1.5,
         };
 
         session.save(&path).unwrap();
@@ -130,5 +153,42 @@ mod tests {
         let path = Session::session_path();
         assert!(path.ends_with("session.toml"));
         assert!(path.to_string_lossy().contains("kora"));
+    }
+
+    #[test]
+    fn default_speed_is_1_0() {
+        let session = Session::default();
+        assert_eq!(session.speed, 1.0);
+    }
+
+    #[test]
+    fn missing_speed_field_defaults_to_1_0() {
+        let toml_str = r#"
+position_ms = 0
+queue = []
+queue_index = 0
+volume_db = 0.0
+shuffle = false
+repeat = "Off"
+"#;
+        let session: Session = toml::from_str(toml_str).unwrap();
+        assert_eq!(session.speed, 1.0);
+    }
+
+    #[test]
+    fn speed_round_trip() {
+        let dir = test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("speed_round_trip.toml");
+
+        let session = Session {
+            speed: 1.75,
+            ..Session::default()
+        };
+        session.save(&path).unwrap();
+        let loaded = Session::load(&path).unwrap();
+        assert_eq!(loaded.speed, 1.75);
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn main() -> Result<()> {
     let volume = cli.volume.unwrap_or(config.default_volume);
     let eq_preset = cli.eq_preset.or(config.eq_preset);
     let theme_name = cli.theme.or_else(|| Some(config.theme.clone()));
+    let rg_mode = playback::replaygain::ReplayGainMode::from_str_config(&config.replaygain);
 
     // Handle --radio: search Radio Browser API and play the first match.
     if let Some(ref query) = cli.radio {
@@ -124,7 +125,8 @@ fn main() -> Result<()> {
         }
         let track = stations[0].to_track();
         eprintln!("Playing: {}", track.display_name());
-        let player = playback::player::Player::new(vec![track], volume, eq_preset.as_deref())?;
+        let player =
+            playback::player::Player::new(vec![track], volume, eq_preset.as_deref(), rg_mode)?;
         tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
         return Ok(());
     }
@@ -149,7 +151,8 @@ fn main() -> Result<()> {
         }
         let track = providers::podcast::episode_to_track(&episodes[0]);
         eprintln!("Playing: {}", track.display_name());
-        let player = playback::player::Player::new(vec![track], volume, eq_preset.as_deref())?;
+        let player =
+            playback::player::Player::new(vec![track], volume, eq_preset.as_deref(), rg_mode)?;
         tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
         return Ok(());
     }
@@ -190,7 +193,7 @@ fn main() -> Result<()> {
     tracing::info!("Playing {} track(s)", tracks.len());
 
     // Launch TUI player
-    let player = playback::player::Player::new(tracks, volume, eq_preset.as_deref())?;
+    let player = playback::player::Player::new(tracks, volume, eq_preset.as_deref(), rg_mode)?;
     tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
 
     Ok(())

--- a/src/playback/mod.rs
+++ b/src/playback/mod.rs
@@ -4,4 +4,6 @@ pub mod engine;
 pub mod eq;
 pub mod fft;
 pub mod player;
+pub mod replaygain;
+pub mod speed;
 pub mod stream_decoder;

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -19,6 +19,8 @@ use crate::core::types::Volume;
 use crate::playback::decoder;
 use crate::playback::eq::{self, EqPreset, Equalizer};
 use crate::playback::fft::SpectrumData;
+use crate::playback::replaygain::{self, ReplayGainInfo, ReplayGainMode};
+use crate::playback::speed;
 use crate::playback::stream_decoder;
 
 /// Playback state visible to the TUI.
@@ -79,6 +81,8 @@ pub enum PlayerCommand {
     #[allow(dead_code)]
     CancelSleepTimer,
     CycleSleepTimer,
+    SpeedUp,
+    SpeedDown,
     CycleEqPreset,
     EqBandUp,
     EqBandDown,
@@ -157,6 +161,11 @@ pub struct Player {
     // Gapless playback: pre-decoded next track
     next_track_samples: Option<PreDecodedTrack>,
 
+    speed: f32,
+
+    replaygain_mode: ReplayGainMode,
+    current_rg: Option<ReplayGainInfo>,
+
     favorites: Favorites,
     sleep_timer: Option<SleepTimer>,
 
@@ -169,7 +178,12 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(tracks: Vec<Track>, volume_db: f32, eq_preset: Option<&str>) -> Result<Self> {
+    pub fn new(
+        tracks: Vec<Track>,
+        volume_db: f32,
+        eq_preset: Option<&str>,
+        replaygain_mode: ReplayGainMode,
+    ) -> Result<Self> {
         let preset = match eq_preset {
             Some(name) => Some(eq::find_preset(name).with_context(|| {
                 format!(
@@ -217,6 +231,9 @@ impl Player {
             playback_start: None,
             pause_offset: Duration::ZERO,
             next_track_samples: None,
+            speed: speed::DEFAULT_SPEED,
+            replaygain_mode,
+            current_rg: None,
             favorites,
             sleep_timer: None,
             spectrum: Arc::new(SpectrumData::new(32)),
@@ -244,13 +261,32 @@ impl Player {
                 .with_context(|| format!("Failed to stream {url}"))?,
         };
 
-        let samples =
-            self.apply_eq_to_samples(decoded.samples, decoded.sample_rate, decoded.channels);
+        let mut samples = decoded.samples;
+
+        // Apply ReplayGain before EQ and speed
+        if self.replaygain_mode != ReplayGainMode::Off {
+            if let TrackSource::File(p) = &self.tracks[self.current_index].source {
+                let rg_info = replaygain::read_replaygain(p);
+                if let Some(gain_db) = replaygain::gain_to_apply(&rg_info, self.replaygain_mode) {
+                    replaygain::apply_replaygain(&mut samples, gain_db);
+                    tracing::info!("ReplayGain: {gain_db:+.1}dB");
+                }
+                self.current_rg = Some(rg_info);
+            } else {
+                self.current_rg = None;
+            }
+        } else {
+            self.current_rg = None;
+        }
+
+        let samples = self.apply_eq_to_samples(samples, decoded.sample_rate, decoded.channels);
+        let samples = speed::apply_speed(&samples, decoded.channels, self.speed);
 
         let total_samples = samples.len() as u64;
         let sample_rate = decoded.sample_rate;
         let channels = decoded.channels;
 
+        // Duration accounts for speed: resampled buffer is shorter/longer
         self.current_duration =
             Duration::from_secs_f64(samples.len() as f64 / (sample_rate as f64 * channels as f64));
         self.current_sample_rate = sample_rate;
@@ -522,6 +558,14 @@ impl Player {
                 }
                 PlayerAction::None
             }
+            PlayerCommand::SpeedUp => {
+                self.speed = speed::clamp_speed(self.speed + speed::SPEED_STEP);
+                PlayerAction::None
+            }
+            PlayerCommand::SpeedDown => {
+                self.speed = speed::clamp_speed(self.speed - speed::SPEED_STEP);
+                PlayerAction::None
+            }
             PlayerCommand::CycleEqPreset => {
                 self.eq_preset_index = (self.eq_preset_index + 1) % eq::PRESETS.len();
                 self.eq_preset = Some(&eq::PRESETS[self.eq_preset_index]);
@@ -749,8 +793,21 @@ impl Player {
             TrackSource::Url(_) => return Ok(()),
         };
 
-        let samples =
-            self.apply_eq_to_samples(decoded.samples, decoded.sample_rate, decoded.channels);
+        let mut samples = decoded.samples;
+
+        // Apply ReplayGain before EQ and speed
+        if self.replaygain_mode != ReplayGainMode::Off
+            && let TrackSource::File(p) = &self.tracks[next_idx].source
+        {
+            let rg_info = replaygain::read_replaygain(p);
+            if let Some(gain_db) = replaygain::gain_to_apply(&rg_info, self.replaygain_mode) {
+                replaygain::apply_replaygain(&mut samples, gain_db);
+                tracing::info!("Pre-decode ReplayGain: {gain_db:+.1}dB");
+            }
+        }
+
+        let samples = self.apply_eq_to_samples(samples, decoded.sample_rate, decoded.channels);
+        let samples = speed::apply_speed(&samples, decoded.channels, self.speed);
 
         tracing::info!(
             "Pre-decoded next track [{}] ({}Hz, {}ch)",
@@ -850,6 +907,21 @@ impl Player {
         self.shuffle
     }
 
+    /// Current playback speed multiplier.
+    pub fn speed(&self) -> f32 {
+        self.speed
+    }
+
+    /// Current ReplayGain mode.
+    pub fn replaygain_mode(&self) -> ReplayGainMode {
+        self.replaygain_mode
+    }
+
+    /// ReplayGain info for the currently playing track.
+    pub fn current_replaygain(&self) -> Option<&ReplayGainInfo> {
+        self.current_rg.as_ref()
+    }
+
     /// Current repeat mode.
     pub fn repeat(&self) -> RepeatMode {
         self.repeat
@@ -924,6 +996,7 @@ impl Player {
             eq_preset: self.eq_preset_name().map(|s| s.to_string()),
             shuffle: self.shuffle,
             repeat: self.repeat.to_string(),
+            speed: self.speed,
         };
         session.save(&Session::session_path())
     }
@@ -942,6 +1015,7 @@ impl Player {
         }
 
         self.shuffle = session.shuffle;
+        self.speed = speed::clamp_speed(session.speed);
         self.repeat = match session.repeat.as_str() {
             "All" => RepeatMode::All,
             "One" => RepeatMode::One,
@@ -1088,7 +1162,7 @@ mod tests {
     }
 
     fn test_player() -> Player {
-        Player::new(vec![], 0.0, None).unwrap()
+        Player::new(vec![], 0.0, None, ReplayGainMode::Off).unwrap()
     }
 
     #[test]
@@ -1313,7 +1387,7 @@ mod tests {
         let tracks: Vec<Track> = (0..count)
             .map(|i| Track::from_file(std::path::PathBuf::from(format!("test_track_{i}.mp3"))))
             .collect();
-        Player::new(tracks, 0.0, None).unwrap()
+        Player::new(tracks, 0.0, None, ReplayGainMode::Off).unwrap()
     }
 
     #[test]

--- a/src/playback/replaygain.rs
+++ b/src/playback/replaygain.rs
@@ -1,0 +1,321 @@
+//! ReplayGain volume normalization — read RG tags and apply gain to decoded audio.
+//!
+//! ReplayGain tags are stored in ID3v2 TXXX frames, Vorbis Comments, or MP4
+//! freeform atoms. This module reads them with `lofty`, parses the gain strings
+//! (e.g. "−3.45 dB"), and applies the resulting linear gain to f32 sample buffers.
+
+use std::path::Path;
+
+use lofty::prelude::*;
+use lofty::tag::ItemKey;
+
+/// ReplayGain metadata extracted from an audio file.
+#[derive(Debug, Clone, Default)]
+pub struct ReplayGainInfo {
+    pub track_gain_db: Option<f32>,
+    pub album_gain_db: Option<f32>,
+    pub track_peak: Option<f32>,
+    pub album_peak: Option<f32>,
+}
+
+/// Which ReplayGain value to apply during playback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReplayGainMode {
+    Off,
+    #[default]
+    Track,
+    Album,
+}
+
+impl ReplayGainMode {
+    /// Parse a config string ("off", "track", "album") into a mode.
+    pub fn from_str_config(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" => Self::Off,
+            "album" => Self::Album,
+            _ => Self::Track,
+        }
+    }
+}
+
+impl std::fmt::Display for ReplayGainMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Off => write!(f, "Off"),
+            Self::Track => write!(f, "Track"),
+            Self::Album => write!(f, "Album"),
+        }
+    }
+}
+
+/// Read ReplayGain tags from an audio file. Returns default (all `None`) on any error.
+pub fn read_replaygain(path: &Path) -> ReplayGainInfo {
+    let tagged_file = match lofty::read_from_path(path) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::debug!("Could not read tags from {}: {e}", path.display());
+            return ReplayGainInfo::default();
+        }
+    };
+
+    let mut info = ReplayGainInfo::default();
+
+    for tag in tagged_file.tags() {
+        if info.track_gain_db.is_none()
+            && let Some(s) = tag.get_string(ItemKey::ReplayGainTrackGain)
+        {
+            info.track_gain_db = parse_gain_value(s);
+        }
+        if info.album_gain_db.is_none()
+            && let Some(s) = tag.get_string(ItemKey::ReplayGainAlbumGain)
+        {
+            info.album_gain_db = parse_gain_value(s);
+        }
+        if info.track_peak.is_none()
+            && let Some(s) = tag.get_string(ItemKey::ReplayGainTrackPeak)
+        {
+            info.track_peak = parse_peak_value(s);
+        }
+        if info.album_peak.is_none()
+            && let Some(s) = tag.get_string(ItemKey::ReplayGainAlbumPeak)
+        {
+            info.album_peak = parse_peak_value(s);
+        }
+    }
+
+    info
+}
+
+/// Determine the dB gain to apply based on mode and available RG info.
+///
+/// - `Track` prefers `track_gain`, falls back to `album_gain`.
+/// - `Album` prefers `album_gain`, falls back to `track_gain`.
+/// - `Off` always returns `None`.
+pub fn gain_to_apply(info: &ReplayGainInfo, mode: ReplayGainMode) -> Option<f32> {
+    match mode {
+        ReplayGainMode::Off => None,
+        ReplayGainMode::Track => info.track_gain_db.or(info.album_gain_db),
+        ReplayGainMode::Album => info.album_gain_db.or(info.track_gain_db),
+    }
+}
+
+/// Apply a dB gain to all samples in-place, clamping to \[-1.0, 1.0\].
+pub fn apply_replaygain(samples: &mut [f32], gain_db: f32) {
+    let linear = 10.0_f32.powf(gain_db / 20.0);
+    for s in samples.iter_mut() {
+        *s = (*s * linear).clamp(-1.0, 1.0);
+    }
+}
+
+/// Parse a ReplayGain gain string like "-3.45 dB" or "−3.45 dB" into f32.
+///
+/// Handles both ASCII minus (`-`, U+002D) and Unicode minus sign (`−`, U+2212).
+fn parse_gain_value(s: &str) -> Option<f32> {
+    // Strip optional " dB" / " db" suffix (case-insensitive)
+    let s = s.trim();
+    let s = s
+        .strip_suffix("dB")
+        .or_else(|| s.strip_suffix("db"))
+        .or_else(|| s.strip_suffix("DB"))
+        .unwrap_or(s)
+        .trim();
+
+    // Replace Unicode minus sign (U+2212) with ASCII minus
+    let s = s.replace('\u{2212}', "-");
+
+    s.parse::<f32>().ok()
+}
+
+/// Parse a peak value (plain float, no "dB" suffix).
+fn parse_peak_value(s: &str) -> Option<f32> {
+    s.trim().parse::<f32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // -- parse_gain_value --
+
+    #[test]
+    fn parse_negative_with_db_suffix() {
+        let v = parse_gain_value("-3.45 dB");
+        assert!((v.unwrap() - (-3.45)).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_unicode_minus_with_db_suffix() {
+        // U+2212 MINUS SIGN
+        let v = parse_gain_value("\u{2212}3.45 dB");
+        assert!((v.unwrap() - (-3.45)).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_without_suffix() {
+        let v = parse_gain_value("-3.45");
+        assert!((v.unwrap() - (-3.45)).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_positive_with_db_suffix() {
+        let v = parse_gain_value("+2.0 dB");
+        assert!((v.unwrap() - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_zero() {
+        let v = parse_gain_value("0.0 dB");
+        assert!((v.unwrap()).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_garbage_returns_none() {
+        assert!(parse_gain_value("not a number").is_none());
+        assert!(parse_gain_value("").is_none());
+        assert!(parse_gain_value("abc dB").is_none());
+    }
+
+    // -- apply_replaygain --
+
+    #[test]
+    fn zero_db_no_change() {
+        let mut samples = vec![0.5, -0.5, 0.0, 1.0, -1.0];
+        let original = samples.clone();
+        apply_replaygain(&mut samples, 0.0);
+        for (a, b) in samples.iter().zip(original.iter()) {
+            assert!((a - b).abs() < 1e-6, "0dB should not change samples");
+        }
+    }
+
+    #[test]
+    fn positive_6db_roughly_doubles() {
+        // +6.02 dB ≈ 2× linear, but we use +6 dB for simplicity
+        let mut samples = vec![0.25, -0.25];
+        apply_replaygain(&mut samples, 6.0);
+        // 10^(6/20) ≈ 1.9953
+        let expected = 0.25 * 10.0_f32.powf(6.0 / 20.0);
+        assert!(
+            (samples[0] - expected).abs() < 0.01,
+            "expected ~{expected}, got {}",
+            samples[0]
+        );
+        assert!(
+            (samples[1] - (-expected)).abs() < 0.01,
+            "expected ~{}, got {}",
+            -expected,
+            samples[1]
+        );
+    }
+
+    #[test]
+    fn clamps_to_valid_range() {
+        let mut samples = vec![0.9, -0.9];
+        // +20 dB = 10× gain → 9.0, should clamp to 1.0
+        apply_replaygain(&mut samples, 20.0);
+        assert_eq!(samples[0], 1.0);
+        assert_eq!(samples[1], -1.0);
+    }
+
+    // -- gain_to_apply --
+
+    #[test]
+    fn track_mode_prefers_track() {
+        let info = ReplayGainInfo {
+            track_gain_db: Some(-3.0),
+            album_gain_db: Some(-5.0),
+            ..Default::default()
+        };
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Track), Some(-3.0));
+    }
+
+    #[test]
+    fn track_mode_falls_back_to_album() {
+        let info = ReplayGainInfo {
+            track_gain_db: None,
+            album_gain_db: Some(-5.0),
+            ..Default::default()
+        };
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Track), Some(-5.0));
+    }
+
+    #[test]
+    fn album_mode_prefers_album() {
+        let info = ReplayGainInfo {
+            track_gain_db: Some(-3.0),
+            album_gain_db: Some(-5.0),
+            ..Default::default()
+        };
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Album), Some(-5.0));
+    }
+
+    #[test]
+    fn album_mode_falls_back_to_track() {
+        let info = ReplayGainInfo {
+            track_gain_db: Some(-3.0),
+            album_gain_db: None,
+            ..Default::default()
+        };
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Album), Some(-3.0));
+    }
+
+    #[test]
+    fn off_mode_returns_none() {
+        let info = ReplayGainInfo {
+            track_gain_db: Some(-3.0),
+            album_gain_db: Some(-5.0),
+            ..Default::default()
+        };
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Off), None);
+    }
+
+    #[test]
+    fn no_tags_returns_none() {
+        let info = ReplayGainInfo::default();
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Track), None);
+        assert_eq!(gain_to_apply(&info, ReplayGainMode::Album), None);
+    }
+
+    // -- read_replaygain --
+
+    #[test]
+    fn read_nonexistent_file_returns_default() {
+        let info = read_replaygain(Path::new("nonexistent_file_that_does_not_exist.mp3"));
+        assert!(info.track_gain_db.is_none());
+        assert!(info.album_gain_db.is_none());
+        assert!(info.track_peak.is_none());
+        assert!(info.album_peak.is_none());
+    }
+
+    // -- ReplayGainMode --
+
+    #[test]
+    fn mode_from_str_config() {
+        assert_eq!(ReplayGainMode::from_str_config("off"), ReplayGainMode::Off);
+        assert_eq!(
+            ReplayGainMode::from_str_config("track"),
+            ReplayGainMode::Track
+        );
+        assert_eq!(
+            ReplayGainMode::from_str_config("album"),
+            ReplayGainMode::Album
+        );
+        assert_eq!(
+            ReplayGainMode::from_str_config("TRACK"),
+            ReplayGainMode::Track
+        );
+        assert_eq!(ReplayGainMode::from_str_config("OFF"), ReplayGainMode::Off);
+        // unknown defaults to Track
+        assert_eq!(
+            ReplayGainMode::from_str_config("garbage"),
+            ReplayGainMode::Track
+        );
+    }
+
+    #[test]
+    fn mode_display() {
+        assert_eq!(ReplayGainMode::Off.to_string(), "Off");
+        assert_eq!(ReplayGainMode::Track.to_string(), "Track");
+        assert_eq!(ReplayGainMode::Album.to_string(), "Album");
+    }
+}

--- a/src/playback/speed.rs
+++ b/src/playback/speed.rs
@@ -1,0 +1,159 @@
+//! Playback speed adjustment via linear interpolation resampling.
+//!
+//! For speed > 1.0, frames are decimated (fewer output frames).
+//! For speed < 1.0, frames are interpolated (more output frames).
+//! Speed 1.0 passes through unchanged.
+
+/// Minimum allowed playback speed.
+pub const MIN_SPEED: f32 = 0.25;
+/// Maximum allowed playback speed.
+pub const MAX_SPEED: f32 = 3.0;
+/// Step size for speed adjustments.
+pub const SPEED_STEP: f32 = 0.25;
+/// Default playback speed (normal).
+pub const DEFAULT_SPEED: f32 = 1.0;
+
+/// Resample `samples` (interleaved, `channels` channels per frame) to change
+/// playback speed. Returns a new buffer with the adjusted number of frames.
+///
+/// Uses linear interpolation between adjacent frames for smooth output.
+pub fn apply_speed(samples: &[f32], channels: usize, speed: f32) -> Vec<f32> {
+    if channels == 0 || samples.is_empty() {
+        return samples.to_vec();
+    }
+    if (speed - 1.0).abs() < 0.01 {
+        return samples.to_vec();
+    }
+
+    let num_frames = samples.len() / channels;
+    let new_num_frames = (num_frames as f64 / speed as f64) as usize;
+    if new_num_frames == 0 {
+        return Vec::new();
+    }
+
+    let mut output = Vec::with_capacity(new_num_frames * channels);
+
+    for i in 0..new_num_frames {
+        let src_pos = i as f64 * speed as f64;
+        let src_idx = src_pos as usize;
+        let frac = (src_pos - src_idx as f64) as f32;
+
+        for ch in 0..channels {
+            let idx0 = src_idx * channels + ch;
+            let idx1 = ((src_idx + 1).min(num_frames - 1)) * channels + ch;
+            let s0 = samples.get(idx0).copied().unwrap_or(0.0);
+            let s1 = samples.get(idx1).copied().unwrap_or(0.0);
+            output.push(s0 + (s1 - s0) * frac);
+        }
+    }
+
+    output
+}
+
+/// Clamp a speed value to the allowed range.
+pub fn clamp_speed(speed: f32) -> f32 {
+    speed.clamp(MIN_SPEED, MAX_SPEED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speed_1_0_returns_same_length() {
+        let samples: Vec<f32> = (0..100).map(|i| i as f32 * 0.01).collect();
+        let result = apply_speed(&samples, 2, 1.0);
+        assert_eq!(result.len(), samples.len());
+        assert_eq!(result, samples);
+    }
+
+    #[test]
+    fn speed_2_0_returns_approximately_half_frames() {
+        let channels = 2;
+        let num_frames = 100;
+        let samples: Vec<f32> = (0..(num_frames * channels))
+            .map(|i| i as f32 * 0.001)
+            .collect();
+        let result = apply_speed(&samples, channels, 2.0);
+        let result_frames = result.len() / channels;
+        assert_eq!(result_frames, num_frames / 2);
+    }
+
+    #[test]
+    fn speed_0_5_returns_approximately_double_frames() {
+        let channels = 2;
+        let num_frames = 100;
+        let samples: Vec<f32> = (0..(num_frames * channels))
+            .map(|i| i as f32 * 0.001)
+            .collect();
+        let result = apply_speed(&samples, channels, 0.5);
+        let result_frames = result.len() / channels;
+        assert_eq!(result_frames, num_frames * 2);
+    }
+
+    #[test]
+    fn linear_interpolation_produces_smooth_values() {
+        // Mono signal: 0.0, 1.0, 2.0, 3.0
+        let samples = vec![0.0_f32, 1.0, 2.0, 3.0];
+        let result = apply_speed(&samples, 1, 0.5);
+        // At 0.5x speed we get ~8 frames from 4. Check monotonically increasing.
+        for i in 1..result.len() {
+            assert!(
+                result[i] >= result[i - 1],
+                "Non-monotonic at index {i}: {} < {}",
+                result[i],
+                result[i - 1]
+            );
+        }
+    }
+
+    #[test]
+    fn stereo_channels_stay_aligned() {
+        // 4 stereo frames: (L0,R0), (L1,R1), (L2,R2), (L3,R3)
+        let samples = vec![
+            0.0, 100.0, // frame 0
+            1.0, 101.0, // frame 1
+            2.0, 102.0, // frame 2
+            3.0, 103.0, // frame 3
+        ];
+        let result = apply_speed(&samples, 2, 2.0);
+        // 2x speed: ~2 output frames
+        assert_eq!(
+            result.len() % 2,
+            0,
+            "output must have even number of samples"
+        );
+        // Each frame's R channel should be ~100 more than L channel
+        for frame in result.chunks(2) {
+            let diff = frame[1] - frame[0];
+            assert!(
+                (diff - 100.0).abs() < 1.0,
+                "Channel misalignment: L={}, R={}",
+                frame[0],
+                frame[1]
+            );
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let result = apply_speed(&[], 2, 1.5);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn clamp_speed_enforces_bounds() {
+        assert_eq!(clamp_speed(0.1), MIN_SPEED);
+        assert_eq!(clamp_speed(5.0), MAX_SPEED);
+        assert_eq!(clamp_speed(1.5), 1.5);
+    }
+
+    #[test]
+    fn extreme_speed_produces_valid_output() {
+        let samples: Vec<f32> = (0..200).map(|i| i as f32 * 0.005).collect();
+        let fast = apply_speed(&samples, 2, 3.0);
+        assert!(!fast.is_empty());
+        let slow = apply_speed(&samples, 2, 0.25);
+        assert!(slow.len() > samples.len());
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -337,6 +337,8 @@ fn run_loop(
                 KeyCode::Char('z') => Some(PlayerCommand::ToggleShuffle),
                 KeyCode::Char('r') => Some(PlayerCommand::CycleRepeat),
                 KeyCode::Char('S') => Some(PlayerCommand::CycleSleepTimer),
+                KeyCode::Char(']') => Some(PlayerCommand::SpeedUp),
+                KeyCode::Char('[') => Some(PlayerCommand::SpeedDown),
                 KeyCode::Char('v') => {
                     visualizer_mode = match visualizer_mode {
                         VisualizerMode::Off => VisualizerMode::Normal,
@@ -570,11 +572,32 @@ fn draw_track_info(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
 
     let repeat_info = format!("  Repeat: {}", player.repeat());
 
+    let speed_info = if (player.speed() - 1.0).abs() >= 0.01 {
+        format!("  Speed: {:.2}x", player.speed())
+    } else {
+        String::new()
+    };
+
+    let rg_info_str =
+        if player.replaygain_mode() != crate::playback::replaygain::ReplayGainMode::Off {
+            if let Some(rg) = player.current_replaygain() {
+                let gain = crate::playback::replaygain::gain_to_apply(rg, player.replaygain_mode());
+                match gain {
+                    Some(db) => format!("  RG: {:+.1}dB", db),
+                    None => String::new(),
+                }
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
     let status = Line::from(vec![
         Span::styled(state_icon, state_style),
         Span::styled(
             format!(
-                "  Vol: {:+.0}dB{eq_info}{shuffle_info}{repeat_info}  Theme: {}",
+                "  Vol: {:+.0}dB{eq_info}{shuffle_info}{repeat_info}{speed_info}{rg_info_str}  Theme: {}",
                 player.volume_db(),
                 theme.name
             ),
@@ -645,6 +668,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
         Span::styled(":Repeat ", theme.help_text),
         Span::styled("v/V", theme.help_key),
         Span::styled(":Viz ", theme.help_text),
+        Span::styled("[/]", theme.help_key),
+        Span::styled(":Speed ", theme.help_text),
         Span::styled("S", theme.help_key),
         Span::styled(":Sleep ", theme.help_text),
         Span::styled("q", theme.help_key),


### PR DESCRIPTION
## Description

Add playback speed control and ReplayGain volume normalization for consistent loudness across tracks.

### What's included

- **Playback speed control**: Press `]`/`[` to adjust speed ±0.25x (range 0.25x–3.0x). Uses linear interpolation resampling — pitch changes with speed (MVP approach). Speed displayed in the status bar when ≠ 1.0x. Persisted in `session.toml`. Especially useful for podcast listeners at 1.5x–2x.
- **ReplayGain volume normalization**: Reads `REPLAYGAIN_TRACK_GAIN` and `REPLAYGAIN_ALBUM_GAIN` tags from ID3v2, Vorbis Comments, and MP4 metadata via lofty. Applies gain after decode but before EQ/speed to normalize loudness. Three modes: `track` (default, per-track normalization), `album` (preserves album dynamics), and `off`. Configurable via `replaygain` in `config.toml`. Clamps output samples to prevent clipping. Displays applied gain in TUI status bar.

## Related Issues

Closes #23, closes #26

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `core/` — Domain models, traits, config
- [x] `playback/` — Decode, DSP, state machine
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (163 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)