### PR TITLE
feat: add audio output device selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ReplayGain volume normalization: reads tags from ID3v2, Vorbis Comments, and MP4 files
 - ReplayGain applies track gain by default, album gain as option, configurable via `replaygain` in `config.toml`
 - ReplayGain info displayed in TUI status bar when active
+- Audio output device selection: `--list-devices` to list, `--device <NAME>` to select, press `d` to cycle in TUI
+- Default audio device configurable via `audio_device` in `config.toml`
+- Graceful fallback to default device when configured device is disconnected
 
 ### Changed
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,6 +25,11 @@
 # "album" preserves relative loudness within albums
 # replaygain = "track"
 
+# Preferred audio output device (case-insensitive substring match)
+# Use `kora --list-devices` to see available devices.
+# If the device is not found at startup, falls back to the system default.
+# audio_device = "Headphones"
+
 # Custom EQ presets (in addition to built-in ones)
 # Each preset has a name and 10 band gains in dB (-12 to +12)
 # Bands: 31Hz, 62Hz, 125Hz, 250Hz, 500Hz, 1kHz, 2kHz, 4kHz, 8kHz, 16kHz

--- a/src/backend/cpal_backend.rs
+++ b/src/backend/cpal_backend.rs
@@ -9,15 +9,13 @@ use rtrb::RingBuffer;
 use crate::playback::fft::SpectrumData;
 
 /// Information about an available audio output device.
-#[derive(Debug)]
-#[allow(dead_code)] // Used in tests and future device selection UI
+#[derive(Debug, Clone)]
 pub struct AudioDevice {
     pub name: String,
     pub is_default: bool,
 }
 
 /// List all available audio output devices.
-#[allow(dead_code)] // Used in tests and future device selection UI
 pub fn list_devices() -> Result<Vec<AudioDevice>> {
     let host = cpal::default_host();
     let default_name = host
@@ -40,6 +38,49 @@ pub fn list_devices() -> Result<Vec<AudioDevice>> {
         .collect();
 
     Ok(devices)
+}
+
+/// Find an audio output device by name (case-insensitive substring match).
+///
+/// Falls back to the default device with a warning if the named device is not found.
+pub fn find_device_by_name(name: &str) -> Result<cpal::Device> {
+    if name.is_empty() {
+        anyhow::bail!("Device name must not be empty");
+    }
+
+    let host = cpal::default_host();
+    let lower = name.to_ascii_lowercase();
+
+    let device = host
+        .output_devices()
+        .context("Failed to enumerate audio output devices")?
+        .find(|d| {
+            d.description()
+                .ok()
+                .map(|desc| desc.name().to_ascii_lowercase().contains(&lower))
+                .unwrap_or(false)
+        });
+
+    match device {
+        Some(d) => Ok(d),
+        None => {
+            tracing::warn!("Configured audio device '{name}' not found — falling back to default");
+            host.default_output_device()
+                .context("No audio output device found. Check your system audio settings.")
+        }
+    }
+}
+
+/// Resolve the output device: use the named device if provided, otherwise default.
+fn resolve_device(device_name: Option<&str>) -> Result<cpal::Device> {
+    match device_name {
+        Some(name) => find_device_by_name(name),
+        None => {
+            let host = cpal::default_host();
+            host.default_output_device()
+                .context("No audio output device found. Check your system audio settings.")
+        }
+    }
 }
 
 /// Play pre-decoded f32 samples through CPAL.
@@ -159,11 +200,9 @@ pub fn play_audio_with_position(
     pause: &Arc<AtomicBool>,
     samples_played: &AtomicU64,
     spectrum: &Arc<SpectrumData>,
+    device_name: Option<&str>,
 ) -> Result<()> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .context("No audio output device found.")?;
+    let device = resolve_device(device_name)?;
 
     let config = StreamConfig {
         channels: channels as u16,
@@ -269,11 +308,9 @@ pub fn play_audio_gapless(
     samples_played: &AtomicU64,
     spectrum: &Arc<SpectrumData>,
     played_next: &AtomicBool,
+    device_name: Option<&str>,
 ) -> Result<()> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .context("No audio output device found.")?;
+    let device = resolve_device(device_name)?;
 
     let config = StreamConfig {
         channels: channels as u16,
@@ -444,6 +481,32 @@ mod tests {
                     "Unexpected error: {msg}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn find_device_by_empty_name_returns_error() {
+        let result = find_device_by_name("");
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("must not be empty"),
+            "Expected empty-name error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn find_device_by_nonexistent_name_falls_back() {
+        // A name that won't match any real device should fall back to default
+        let result = find_device_by_name("__nonexistent_device_xyz_12345__");
+        // Either falls back to default (Ok) or no default available (Err) — both OK
+        if let Err(e) = &result {
+            let msg = format!("{e:#}");
+            assert!(
+                msg.contains("No audio output device"),
+                "Unexpected error: {msg}"
+            );
         }
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -30,6 +30,8 @@ pub struct KoraConfig {
     pub buffer_ms: u32,
     /// ReplayGain mode: "off", "track" (default), or "album".
     pub replaygain: String,
+    /// Preferred audio output device name (substring match, case-insensitive).
+    pub audio_device: Option<String>,
     /// Custom EQ presets (in addition to built-in ones).
     #[serde(default)]
     pub custom_eq_presets: Vec<CustomEqPreset>,
@@ -45,6 +47,7 @@ impl Default for KoraConfig {
             sample_rate: None,
             buffer_ms: 200,
             replaygain: "track".to_string(),
+            audio_device: None,
             custom_eq_presets: Vec::new(),
         }
     }
@@ -132,6 +135,7 @@ mod tests {
         assert!(config.sample_rate.is_none());
         assert_eq!(config.buffer_ms, 200);
         assert_eq!(config.replaygain, "track");
+        assert!(config.audio_device.is_none());
         assert!(config.custom_eq_presets.is_empty());
     }
 
@@ -145,6 +149,7 @@ mod tests {
             sample_rate: Some(48000),
             buffer_ms: 300,
             replaygain: "album".to_string(),
+            audio_device: Some("Headphones".to_string()),
             custom_eq_presets: vec![CustomEqPreset {
                 name: "Test".to_string(),
                 gains: [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, -2.0, -3.0, -4.0, -5.0],
@@ -161,6 +166,7 @@ mod tests {
         assert_eq!(loaded.sample_rate, config.sample_rate);
         assert_eq!(loaded.buffer_ms, config.buffer_ms);
         assert_eq!(loaded.replaygain, config.replaygain);
+        assert_eq!(loaded.audio_device, config.audio_device);
         assert_eq!(loaded.custom_eq_presets.len(), 1);
         assert_eq!(loaded.custom_eq_presets[0].name, "Test");
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,14 @@ struct Cli {
     /// Fetch a podcast RSS feed and play the most recent episode
     #[arg(long, value_name = "URL")]
     podcast: Option<String>,
+
+    /// List available audio output devices and exit
+    #[arg(long)]
+    list_devices: bool,
+
+    /// Select audio output device by name (case-insensitive substring match)
+    #[arg(long, value_name = "NAME")]
+    device: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -100,10 +108,25 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    if cli.list_devices {
+        let devices = backend::cpal_backend::list_devices()?;
+        if devices.is_empty() {
+            println!("No audio output devices found.");
+        } else {
+            println!("Available audio output devices:");
+            for d in &devices {
+                let marker = if d.is_default { " (default)" } else { "" };
+                println!("  {}{marker}", d.name);
+            }
+        }
+        return Ok(());
+    }
+
     let volume = cli.volume.unwrap_or(config.default_volume);
     let eq_preset = cli.eq_preset.or(config.eq_preset);
     let theme_name = cli.theme.or_else(|| Some(config.theme.clone()));
     let rg_mode = playback::replaygain::ReplayGainMode::from_str_config(&config.replaygain);
+    let device_name = cli.device.or(config.audio_device);
 
     // Handle --radio: search Radio Browser API and play the first match.
     if let Some(ref query) = cli.radio {
@@ -125,8 +148,13 @@ fn main() -> Result<()> {
         }
         let track = stations[0].to_track();
         eprintln!("Playing: {}", track.display_name());
-        let player =
-            playback::player::Player::new(vec![track], volume, eq_preset.as_deref(), rg_mode)?;
+        let player = playback::player::Player::new(
+            vec![track],
+            volume,
+            eq_preset.as_deref(),
+            rg_mode,
+            device_name.clone(),
+        )?;
         tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
         return Ok(());
     }
@@ -151,8 +179,13 @@ fn main() -> Result<()> {
         }
         let track = providers::podcast::episode_to_track(&episodes[0]);
         eprintln!("Playing: {}", track.display_name());
-        let player =
-            playback::player::Player::new(vec![track], volume, eq_preset.as_deref(), rg_mode)?;
+        let player = playback::player::Player::new(
+            vec![track],
+            volume,
+            eq_preset.as_deref(),
+            rg_mode,
+            device_name.clone(),
+        )?;
         tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
         return Ok(());
     }
@@ -193,7 +226,8 @@ fn main() -> Result<()> {
     tracing::info!("Playing {} track(s)", tracks.len());
 
     // Launch TUI player
-    let player = playback::player::Player::new(tracks, volume, eq_preset.as_deref(), rg_mode)?;
+    let player =
+        playback::player::Player::new(tracks, volume, eq_preset.as_deref(), rg_mode, device_name)?;
     tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
 
     Ok(())

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -92,6 +92,9 @@ pub enum PlayerCommand {
     ToggleVisualizer,
     #[allow(dead_code)]
     ToggleFullscreenVisualizer,
+    #[allow(dead_code)] // Available for CLI/IPC device listing
+    ListDevices,
+    SetDevice(String),
     Quit,
 }
 
@@ -168,6 +171,7 @@ pub struct Player {
 
     favorites: Favorites,
     sleep_timer: Option<SleepTimer>,
+    device_name: Option<String>,
 
     spectrum: Arc<SpectrumData>,
 
@@ -183,6 +187,7 @@ impl Player {
         volume_db: f32,
         eq_preset: Option<&str>,
         replaygain_mode: ReplayGainMode,
+        device_name: Option<String>,
     ) -> Result<Self> {
         let preset = match eq_preset {
             Some(name) => Some(eq::find_preset(name).with_context(|| {
@@ -236,6 +241,7 @@ impl Player {
             current_rg: None,
             favorites,
             sleep_timer: None,
+            device_name,
             spectrum: Arc::new(SpectrumData::new(32)),
             stop_flag: Arc::new(AtomicBool::new(false)),
             pause_flag: Arc::new(AtomicBool::new(false)),
@@ -350,6 +356,7 @@ impl Player {
         let pause = self.pause_flag.clone();
         let position = self.position.clone();
         let spectrum = self.spectrum.clone();
+        let device_name = self.device_name.clone();
 
         let handle = std::thread::spawn(move || {
             cpal_backend::play_audio_with_position(
@@ -361,6 +368,7 @@ impl Player {
                 &pause,
                 &position.samples_played,
                 &spectrum,
+                device_name.as_deref(),
             )
         });
 
@@ -389,6 +397,7 @@ impl Player {
         let spectrum = self.spectrum.clone();
         let played_next = Arc::new(AtomicBool::new(false));
         let played_next_clone = played_next.clone();
+        let device_name = self.device_name.clone();
 
         let handle = std::thread::spawn(move || {
             cpal_backend::play_audio_gapless(
@@ -402,6 +411,7 @@ impl Player {
                 &position.samples_played,
                 &spectrum,
                 &played_next_clone,
+                device_name.as_deref(),
             )
         });
 
@@ -598,6 +608,14 @@ impl Player {
             }
             PlayerCommand::ToggleVisualizer | PlayerCommand::ToggleFullscreenVisualizer => {
                 // Handled in the TUI layer — no playback state change needed.
+                PlayerAction::None
+            }
+            PlayerCommand::ListDevices => {
+                // Handled in the TUI/CLI layer — no playback state change needed.
+                PlayerAction::None
+            }
+            PlayerCommand::SetDevice(name) => {
+                self.device_name = Some(name);
                 PlayerAction::None
             }
             PlayerCommand::Quit => PlayerAction::Quit,
@@ -927,6 +945,11 @@ impl Player {
         self.repeat
     }
 
+    /// Current audio output device name.
+    pub fn device_name(&self) -> Option<&str> {
+        self.device_name.as_deref()
+    }
+
     /// Return the next track index respecting shuffle order, or `None` at end.
     fn next_index(&self) -> Option<usize> {
         if self.tracks.is_empty() {
@@ -1162,7 +1185,7 @@ mod tests {
     }
 
     fn test_player() -> Player {
-        Player::new(vec![], 0.0, None, ReplayGainMode::Off).unwrap()
+        Player::new(vec![], 0.0, None, ReplayGainMode::Off, None).unwrap()
     }
 
     #[test]
@@ -1387,7 +1410,7 @@ mod tests {
         let tracks: Vec<Track> = (0..count)
             .map(|i| Track::from_file(std::path::PathBuf::from(format!("test_track_{i}.mp3"))))
             .collect();
-        Player::new(tracks, 0.0, None, ReplayGainMode::Off).unwrap()
+        Player::new(tracks, 0.0, None, ReplayGainMode::Off, None).unwrap()
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -117,6 +117,7 @@ fn run_loop(
     let mut file_browser: Option<FileBrowser> = None;
     let mut show_eq = false;
     let mut visualizer_mode = VisualizerMode::Normal;
+    let mut status_message: Option<(String, Instant)> = None;
 
     // Gapless playback state
     let mut gapless_played_next: Option<Arc<AtomicBool>> = None;
@@ -132,8 +133,16 @@ fn run_loop(
                 file_browser.as_ref(),
                 show_eq,
                 visualizer_mode,
+                status_message.as_ref().map(|(msg, _)| msg.as_str()),
             )
         })?;
+
+        // Clear expired status messages (show for 3 seconds)
+        if let Some((_, time)) = &status_message
+            && time.elapsed() > Duration::from_secs(3)
+        {
+            status_message = None;
+        }
 
         // Tick sleep timer
         if let SleepAction::Stop = player.tick_sleep_timer() {
@@ -325,6 +334,35 @@ fn run_loop(
                     *theme = themes[*theme_index].clone();
                     None
                 }
+                KeyCode::Char('d') => {
+                    match crate::backend::cpal_backend::list_devices() {
+                        Ok(devices) if !devices.is_empty() => {
+                            let current_name = player.device_name().unwrap_or("");
+                            let current_pos = devices
+                                .iter()
+                                .position(|d| d.name.eq_ignore_ascii_case(current_name))
+                                .unwrap_or(devices.len()); // if not found, wraps to 0
+                            let next_idx = (current_pos + 1) % devices.len();
+                            let next_device = &devices[next_idx];
+                            let msg = if next_device.is_default {
+                                format!("Device: {} (default)", next_device.name)
+                            } else {
+                                format!("Device: {}", next_device.name)
+                            };
+                            player
+                                .handle_command(PlayerCommand::SetDevice(next_device.name.clone()));
+                            status_message = Some((msg, Instant::now()));
+                        }
+                        Ok(_) => {
+                            status_message =
+                                Some(("No audio devices found".to_string(), Instant::now()));
+                        }
+                        Err(e) => {
+                            status_message = Some((format!("Device error: {e}"), Instant::now()));
+                        }
+                    }
+                    None
+                }
                 KeyCode::Char('o') => {
                     let start_dir = crate::core::config::KoraConfig::load()
                         .ok()
@@ -445,6 +483,7 @@ fn draw(
     file_browser: Option<&FileBrowser>,
     show_eq: bool,
     visualizer_mode: VisualizerMode,
+    status_message: Option<&str>,
 ) {
     let area = frame.area();
 
@@ -482,7 +521,7 @@ fn draw(
                 draw_playlist(frame, chunks[1], player, theme);
             }
         }
-        draw_status_bar(frame, chunks[2], player, theme);
+        draw_status_bar(frame, chunks[2], player, theme, status_message);
     }
 
     // File browser overlay
@@ -642,7 +681,13 @@ fn draw_playlist(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) 
     frame.render_widget(list, area);
 }
 
-fn draw_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) {
+fn draw_status_bar(
+    frame: &mut Frame,
+    area: Rect,
+    player: &Player,
+    theme: &Theme,
+    status_message: Option<&str>,
+) {
     let mut spans = vec![
         Span::styled("Spc", theme.help_key),
         Span::styled(":Play/Pause ", theme.help_text),
@@ -672,6 +717,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
         Span::styled(":Speed ", theme.help_text),
         Span::styled("S", theme.help_key),
         Span::styled(":Sleep ", theme.help_text),
+        Span::styled("d", theme.help_key),
+        Span::styled(":Device ", theme.help_text),
         Span::styled("q", theme.help_key),
         Span::styled(":Quit", theme.help_text),
     ];
@@ -686,6 +733,10 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
             format!(" | Sleep: {mins}:{secs:02}")
         };
         spans.push(Span::styled(sleep_text, theme.status_info));
+    }
+
+    if let Some(msg) = status_message {
+        spans.push(Span::styled(format!(" | {msg}"), theme.status_info));
     }
 
     let help = Line::from(spans);


### PR DESCRIPTION
## Description

Add audio output device selection — list, choose, and switch devices from the CLI or during playback.

### What's included

- **Device listing**: `kora --list-devices` shows all available audio output devices with the default marked
- **Device selection via CLI**: `kora --device "Headphones"` selects a device by name (case-insensitive substring match). Falls back to default with a warning if the device isn't found
- **Live device cycling in TUI**: Press `d` to cycle through available devices. A status message shows the selected device name (auto-expires after 3 seconds). Device change takes effect on the next track
- **Config persistence**: Set `audio_device = "Headphones"` in `config.toml` for a persistent default. CLI `--device` flag overrides config
- **Graceful disconnection handling**: If the configured device disappears (e.g., Bluetooth headphones disconnect), kora falls back to the system default device with a warning — no crash

## Related Issues

Closes #27

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `core/` — Domain models, traits, config
- [x] `playback/` — Decode, DSP, state machine
- [x] `backend/` — Audio output (CPAL)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (165 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)