### PR TITLE
feat: add synced lyrics display and AAC/ALAC format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Audio output device selection: `--list-devices` to list, `--device <NAME>` to select, press `d` to cycle in TUI
 - Default audio device configurable via `audio_device` in `config.toml`
 - Graceful fallback to default device when configured device is disconnected
+- Synced lyrics display: press `y` to toggle, auto-scrolling with current line highlighted
+- Lyrics loaded from `.lrc` sidecar files or embedded tags (ID3v2 USLT, Vorbis LYRICS)
+- AAC and ALAC (M4A) format support via symphonia
+- Helpful error message when attempting to play WMA files (requires ffmpeg)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Audio decoding (pure Rust, no C deps)
-symphonia = { version = "0.5", features = ["mp3", "flac", "ogg", "vorbis", "wav", "pcm"] }
+symphonia = { version = "0.5", features = ["mp3", "flac", "ogg", "vorbis", "wav", "pcm", "isomp4", "aac", "alac"] }
 
 # Audio output (cross-platform)
 cpal = "0.17"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kora --list-eq-presets
 
 ## Supported Formats
 
-MP3, FLAC, OGG Vorbis, Opus, WAV — decoded natively in Rust via [symphonia](https://github.com/pdeljanov/Symphonia) (no C dependencies).
+MP3, FLAC, OGG Vorbis, Opus, WAV, AAC, ALAC (M4A) — decoded natively in Rust via [symphonia](https://github.com/pdeljanov/Symphonia) (no C dependencies).
 
 ## Install
 

--- a/src/playback/decoder.rs
+++ b/src/playback/decoder.rs
@@ -41,7 +41,18 @@ pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
             &FormatOptions::default(),
             &MetadataOptions::default(),
         )
-        .with_context(|| format!("Unsupported or corrupt audio file: {}", path.display()))?;
+        .with_context(|| {
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext.eq_ignore_ascii_case("wma") {
+                format!(
+                    "Cannot decode {}: WMA files require ffmpeg. \
+                     Install ffmpeg and ensure it's in your PATH.",
+                    path.display()
+                )
+            } else {
+                format!("Unsupported or corrupt audio file: {}", path.display())
+            }
+        })?;
 
     let mut format = probed.format;
 
@@ -248,5 +259,25 @@ mod tests {
         assert!(result.is_err(), "Large garbage file should fail to decode");
 
         std::fs::remove_file(&large_garbage).ok();
+    }
+
+    #[test]
+    fn decode_wma_file_shows_ffmpeg_hint() {
+        let dir = std::env::temp_dir().join("kora_test_decode");
+        std::fs::create_dir_all(&dir).unwrap();
+        let wma_file = dir.join("test.wma");
+        let mut f = File::create(&wma_file).unwrap();
+        f.write_all(&[0x30, 0x26, 0xB2, 0x75, 0x8E, 0x66, 0xCF, 0x11])
+            .unwrap();
+
+        let result = decode_file(&wma_file);
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("ffmpeg"),
+            "WMA error should mention ffmpeg: {err}"
+        );
+
+        std::fs::remove_file(&wma_file).ok();
     }
 }

--- a/src/playback/lyrics.rs
+++ b/src/playback/lyrics.rs
@@ -1,0 +1,367 @@
+//! LRC lyrics parser and synced lyrics display support.
+//!
+//! Parses `.lrc` sidecar files and embedded lyrics tags to provide
+//! time-synced lyrics for the TUI display.
+
+use std::path::Path;
+
+use lofty::prelude::*;
+use lofty::tag::ItemKey;
+
+use crate::core::track::{Track, TrackSource};
+
+/// A single timed lyric line.
+#[derive(Debug, Clone)]
+pub struct LyricLine {
+    pub timestamp_ms: u64,
+    pub text: String,
+}
+
+/// Parsed lyrics for a track.
+#[derive(Debug, Clone, Default)]
+pub struct Lyrics {
+    pub lines: Vec<LyricLine>,
+    pub source: LyricsSource,
+}
+
+/// Where the lyrics were loaded from.
+#[derive(Debug, Clone, Default)]
+pub enum LyricsSource {
+    #[default]
+    None,
+    #[allow(dead_code)]
+    LrcFile(String),
+    EmbeddedTag,
+}
+
+/// Parse LRC format content into [`Lyrics`].
+///
+/// Handles `[mm:ss.xx]` and `[mm:ss]` timestamps, multiple timestamps per line,
+/// and skips metadata lines like `[ar:Artist]`.
+pub fn parse_lrc(content: &str) -> Lyrics {
+    let mut lines = Vec::new();
+
+    for raw_line in content.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut timestamps = Vec::new();
+        let mut rest = trimmed;
+
+        // Extract all [mm:ss.xx] timestamps from the beginning of the line
+        while rest.starts_with('[') {
+            let Some(close) = rest.find(']') else {
+                break;
+            };
+            let tag = &rest[1..close];
+            if let Some(ts) = parse_timestamp(tag) {
+                timestamps.push(ts);
+                rest = &rest[close + 1..];
+            } else {
+                // Metadata tag like [ar:Artist] — skip entire line
+                if is_metadata_tag(tag) {
+                    timestamps.clear();
+                    break;
+                }
+                // Unknown bracket content — stop parsing timestamps
+                break;
+            }
+        }
+
+        if timestamps.is_empty() {
+            continue;
+        }
+
+        let text = rest.trim().to_string();
+        for ts in timestamps {
+            lines.push(LyricLine {
+                timestamp_ms: ts,
+                text: text.clone(),
+            });
+        }
+    }
+
+    lines.sort_by_key(|l| l.timestamp_ms);
+
+    Lyrics {
+        lines,
+        source: LyricsSource::None,
+    }
+}
+
+/// Parse a timestamp string like "01:30.50" or "01:30" into milliseconds.
+fn parse_timestamp(tag: &str) -> Option<u64> {
+    let parts: Vec<&str> = tag.split(':').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let minutes: u64 = parts[0].parse().ok()?;
+
+    // Seconds may have a decimal component
+    let sec_parts: Vec<&str> = parts[1].split('.').collect();
+    let seconds: u64 = sec_parts[0].parse().ok()?;
+
+    let centiseconds: u64 = if sec_parts.len() > 1 {
+        let frac = sec_parts[1];
+        match frac.len() {
+            1 => frac.parse::<u64>().ok()? * 100,
+            2 => frac.parse::<u64>().ok()? * 10,
+            3 => frac.parse::<u64>().ok()?,
+            _ => frac[..3].parse::<u64>().ok()?,
+        }
+    } else {
+        0
+    };
+
+    Some(minutes * 60_000 + seconds * 1_000 + centiseconds)
+}
+
+/// Check if a bracket tag is an LRC metadata tag (e.g. `ar:`, `ti:`, `al:`).
+fn is_metadata_tag(tag: &str) -> bool {
+    let lower = tag.to_ascii_lowercase();
+    lower.starts_with("ar:")
+        || lower.starts_with("ti:")
+        || lower.starts_with("al:")
+        || lower.starts_with("au:")
+        || lower.starts_with("by:")
+        || lower.starts_with("offset:")
+        || lower.starts_with("re:")
+        || lower.starts_with("ve:")
+        || lower.starts_with("length:")
+}
+
+/// Load lyrics for a track, trying sidecar `.lrc` file first, then embedded tags.
+pub fn load_lyrics_for_track(track: &Track) -> Lyrics {
+    match &track.source {
+        TrackSource::File(path) => {
+            // 1. Try sidecar .lrc file
+            if let Some(lyrics) = try_load_lrc_file(path) {
+                return lyrics;
+            }
+            // 2. Try embedded lyrics tag
+            if let Some(lyrics) = try_load_embedded_lyrics(path) {
+                return lyrics;
+            }
+            Lyrics::default()
+        }
+        TrackSource::Url(_) => Lyrics::default(),
+    }
+}
+
+/// Try to load a `.lrc` sidecar file next to the audio file.
+fn try_load_lrc_file(audio_path: &Path) -> Option<Lyrics> {
+    let lrc_path = audio_path.with_extension("lrc");
+    let content = std::fs::read_to_string(&lrc_path).ok()?;
+    let mut lyrics = parse_lrc(&content);
+    if lyrics.lines.is_empty() {
+        return None;
+    }
+    lyrics.source = LyricsSource::LrcFile(
+        lrc_path
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+    );
+    Some(lyrics)
+}
+
+/// Try to read embedded lyrics from audio file tags via lofty.
+fn try_load_embedded_lyrics(path: &Path) -> Option<Lyrics> {
+    let tagged_file = lofty::read_from_path(path).ok()?;
+
+    for tag in tagged_file.tags() {
+        // Try LYRICS item key (covers USLT for ID3, LYRICS for Vorbis)
+        if let Some(text) = tag.get_string(ItemKey::Lyrics)
+            && !text.trim().is_empty()
+        {
+            let mut lyrics = parse_lrc(text);
+            if !lyrics.lines.is_empty() {
+                lyrics.source = LyricsSource::EmbeddedTag;
+                return Some(lyrics);
+            }
+            // Plain text lyrics without timestamps — treat as single block
+            let lines: Vec<LyricLine> = text
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .enumerate()
+                .map(|(i, line)| LyricLine {
+                    // Space lines 5 seconds apart for unsynced display
+                    timestamp_ms: i as u64 * 5000,
+                    text: line.trim().to_string(),
+                })
+                .collect();
+            if !lines.is_empty() {
+                return Some(Lyrics {
+                    lines,
+                    source: LyricsSource::EmbeddedTag,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+/// Find the index of the lyric line that should be highlighted at the given
+/// playback position (the last line whose timestamp <= position).
+pub fn current_line_index(lyrics: &Lyrics, position_ms: u64) -> Option<usize> {
+    if lyrics.lines.is_empty() {
+        return None;
+    }
+
+    // Binary search for the last line with timestamp <= position_ms
+    match lyrics
+        .lines
+        .binary_search_by_key(&position_ms, |l| l.timestamp_ms)
+    {
+        Ok(i) => {
+            // Exact match — find the last line with the same timestamp
+            let mut idx = i;
+            while idx + 1 < lyrics.lines.len() && lyrics.lines[idx + 1].timestamp_ms == position_ms
+            {
+                idx += 1;
+            }
+            Some(idx)
+        }
+        Err(0) => {
+            // Position is before the first line
+            if position_ms < lyrics.lines[0].timestamp_ms {
+                None
+            } else {
+                Some(0)
+            }
+        }
+        Err(i) => Some(i - 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_lrc_line() {
+        let lyrics = parse_lrc("[00:12.34]Hello");
+        assert_eq!(lyrics.lines.len(), 1);
+        assert_eq!(lyrics.lines[0].timestamp_ms, 12340);
+        assert_eq!(lyrics.lines[0].text, "Hello");
+    }
+
+    #[test]
+    fn parse_lrc_seconds_only() {
+        let lyrics = parse_lrc("[01:30]Text");
+        assert_eq!(lyrics.lines.len(), 1);
+        assert_eq!(lyrics.lines[0].timestamp_ms, 90000);
+        assert_eq!(lyrics.lines[0].text, "Text");
+    }
+
+    #[test]
+    fn parse_multiple_timestamps() {
+        let lyrics = parse_lrc("[00:12.00][00:24.00]Repeated line");
+        assert_eq!(lyrics.lines.len(), 2);
+        assert_eq!(lyrics.lines[0].timestamp_ms, 12000);
+        assert_eq!(lyrics.lines[0].text, "Repeated line");
+        assert_eq!(lyrics.lines[1].timestamp_ms, 24000);
+        assert_eq!(lyrics.lines[1].text, "Repeated line");
+    }
+
+    #[test]
+    fn skip_metadata_lines() {
+        let content = "[ar:Artist]\n[ti:Title]\n[al:Album]\n[00:05.00]First line";
+        let lyrics = parse_lrc(content);
+        assert_eq!(lyrics.lines.len(), 1);
+        assert_eq!(lyrics.lines[0].text, "First line");
+    }
+
+    #[test]
+    fn empty_content_returns_empty() {
+        let lyrics = parse_lrc("");
+        assert!(lyrics.lines.is_empty());
+    }
+
+    #[test]
+    fn current_line_index_basic() {
+        let lyrics = Lyrics {
+            lines: vec![
+                LyricLine {
+                    timestamp_ms: 5000,
+                    text: "A".into(),
+                },
+                LyricLine {
+                    timestamp_ms: 10000,
+                    text: "B".into(),
+                },
+                LyricLine {
+                    timestamp_ms: 15000,
+                    text: "C".into(),
+                },
+            ],
+            source: LyricsSource::None,
+        };
+
+        // Before any line
+        assert_eq!(current_line_index(&lyrics, 0), None);
+        assert_eq!(current_line_index(&lyrics, 4999), None);
+
+        // On first line
+        assert_eq!(current_line_index(&lyrics, 5000), Some(0));
+        assert_eq!(current_line_index(&lyrics, 7000), Some(0));
+
+        // On second line
+        assert_eq!(current_line_index(&lyrics, 10000), Some(1));
+        assert_eq!(current_line_index(&lyrics, 12000), Some(1));
+
+        // On third line
+        assert_eq!(current_line_index(&lyrics, 15000), Some(2));
+        assert_eq!(current_line_index(&lyrics, 99999), Some(2));
+    }
+
+    #[test]
+    fn current_line_index_empty_returns_none() {
+        let lyrics = Lyrics::default();
+        assert_eq!(current_line_index(&lyrics, 1000), None);
+    }
+
+    #[test]
+    fn load_lyrics_nonexistent_file() {
+        let track = Track::from_file(std::path::PathBuf::from("/nonexistent/path/song.mp3"));
+        let lyrics = load_lyrics_for_track(&track);
+        assert!(lyrics.lines.is_empty());
+    }
+
+    #[test]
+    fn parse_lrc_with_three_digit_ms() {
+        let lyrics = parse_lrc("[00:01.234]Precise");
+        assert_eq!(lyrics.lines.len(), 1);
+        assert_eq!(lyrics.lines[0].timestamp_ms, 1234);
+    }
+
+    #[test]
+    fn parse_lrc_sorted_output() {
+        let content = "[00:30.00]Second\n[00:10.00]First\n[00:50.00]Third";
+        let lyrics = parse_lrc(content);
+        assert_eq!(lyrics.lines.len(), 3);
+        assert_eq!(lyrics.lines[0].text, "First");
+        assert_eq!(lyrics.lines[1].text, "Second");
+        assert_eq!(lyrics.lines[2].text, "Third");
+    }
+
+    #[test]
+    fn parse_lrc_empty_text_line() {
+        let content = "[00:10.00]\n[00:20.00]With text";
+        let lyrics = parse_lrc(content);
+        assert_eq!(lyrics.lines.len(), 2);
+        assert_eq!(lyrics.lines[0].text, "");
+        assert_eq!(lyrics.lines[1].text, "With text");
+    }
+
+    #[test]
+    fn parse_lrc_single_digit_fraction() {
+        let lyrics = parse_lrc("[00:05.5]Half");
+        assert_eq!(lyrics.lines.len(), 1);
+        assert_eq!(lyrics.lines[0].timestamp_ms, 5500);
+    }
+}

--- a/src/playback/mod.rs
+++ b/src/playback/mod.rs
@@ -3,6 +3,7 @@ pub mod dsp;
 pub mod engine;
 pub mod eq;
 pub mod fft;
+pub mod lyrics;
 pub mod player;
 pub mod replaygain;
 pub mod speed;

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -19,6 +19,7 @@ use crate::core::types::Volume;
 use crate::playback::decoder;
 use crate::playback::eq::{self, EqPreset, Equalizer};
 use crate::playback::fft::SpectrumData;
+use crate::playback::lyrics::{self, Lyrics};
 use crate::playback::replaygain::{self, ReplayGainInfo, ReplayGainMode};
 use crate::playback::speed;
 use crate::playback::stream_decoder;
@@ -172,6 +173,7 @@ pub struct Player {
     favorites: Favorites,
     sleep_timer: Option<SleepTimer>,
     device_name: Option<String>,
+    current_lyrics: Lyrics,
 
     spectrum: Arc<SpectrumData>,
 
@@ -242,6 +244,7 @@ impl Player {
             favorites,
             sleep_timer: None,
             device_name,
+            current_lyrics: Lyrics::default(),
             spectrum: Arc::new(SpectrumData::new(32)),
             stop_flag: Arc::new(AtomicBool::new(false)),
             pause_flag: Arc::new(AtomicBool::new(false)),
@@ -266,6 +269,9 @@ impl Player {
             TrackSource::Url(url) => stream_decoder::decode_url(url)
                 .with_context(|| format!("Failed to stream {url}"))?,
         };
+
+        // Load lyrics for the new track
+        self.current_lyrics = lyrics::load_lyrics_for_track(track);
 
         let mut samples = decoded.samples;
 
@@ -319,6 +325,11 @@ impl Player {
     /// Load pre-decoded track data into the player without re-decoding.
     /// Used for gapless transitions where the next track was already decoded.
     pub fn play_predecoded(&mut self, pre: PreDecodedTrack) {
+        // Load lyrics for the new track
+        if let Some(track) = self.tracks.get(self.current_index) {
+            self.current_lyrics = lyrics::load_lyrics_for_track(track);
+        }
+
         let total_samples = pre.samples.len() as u64;
         self.current_duration = Duration::from_secs_f64(
             pre.samples.len() as f64 / (pre.sample_rate as f64 * pre.channels as f64),
@@ -645,6 +656,17 @@ impl Player {
     /// Get current track (if any).
     pub fn current_track(&self) -> Option<&Track> {
         self.tracks.get(self.current_index)
+    }
+
+    /// Get lyrics for the current track.
+    pub fn lyrics(&self) -> &Lyrics {
+        &self.current_lyrics
+    }
+
+    /// Check if the current track has lyrics loaded.
+    #[allow(dead_code)] // Available for CLI/IPC use
+    pub fn has_lyrics(&self) -> bool {
+        !self.current_lyrics.lines.is_empty()
     }
 
     /// Get current track index and total count.

--- a/src/playback/stream_decoder.rs
+++ b/src/playback/stream_decoder.rs
@@ -57,7 +57,7 @@ pub fn content_type_to_hint(content_type: &str) -> Option<&'static str> {
         "audio/wav" | "audio/x-wav" | "audio/wave" => Some("wav"),
         "audio/opus" => Some("opus"),
         "audio/aac" | "audio/x-aac" => Some("aac"),
-        "audio/mp4" | "audio/x-m4a" => Some("m4a"),
+        "audio/mp4" | "audio/x-m4a" | "audio/alac" => Some("m4a"),
         _ => None,
     }
 }
@@ -315,6 +315,7 @@ mod tests {
     fn content_type_maps_audio_m4a() {
         assert_eq!(content_type_to_hint("audio/mp4"), Some("m4a"));
         assert_eq!(content_type_to_hint("audio/x-m4a"), Some("m4a"));
+        assert_eq!(content_type_to_hint("audio/alac"), Some("m4a"));
     }
 
     #[test]

--- a/src/providers/local.rs
+++ b/src/providers/local.rs
@@ -63,3 +63,35 @@ fn is_audio_file(path: &Path) -> bool {
         .map(|e| SUPPORTED_EXTENSIONS.contains(&e.to_lowercase().as_str()))
         .unwrap_or(false)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_extensions_include_aac_m4a() {
+        assert!(
+            SUPPORTED_EXTENSIONS.contains(&"aac"),
+            "SUPPORTED_EXTENSIONS must include aac"
+        );
+        assert!(
+            SUPPORTED_EXTENSIONS.contains(&"m4a"),
+            "SUPPORTED_EXTENSIONS must include m4a"
+        );
+    }
+
+    #[test]
+    fn is_audio_file_accepts_m4a() {
+        assert!(is_audio_file(Path::new("song.m4a")));
+    }
+
+    #[test]
+    fn is_audio_file_accepts_aac() {
+        assert!(is_audio_file(Path::new("song.aac")));
+    }
+
+    #[test]
+    fn is_audio_file_rejects_txt() {
+        assert!(!is_audio_file(Path::new("readme.txt")));
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -20,6 +20,7 @@ use super::file_browser::FileBrowser;
 use super::theme::{self, Theme};
 use crate::core::session::Session;
 use crate::core::track::Track;
+use crate::playback::lyrics;
 use crate::playback::player::{PlaybackState, Player, PlayerAction, PlayerCommand, SleepAction};
 
 /// Block characters for fine-grained bar height rendering (1/8 increments).
@@ -116,6 +117,7 @@ fn run_loop(
     let mut last_save = Instant::now();
     let mut file_browser: Option<FileBrowser> = None;
     let mut show_eq = false;
+    let mut show_lyrics = false;
     let mut visualizer_mode = VisualizerMode::Normal;
     let mut status_message: Option<(String, Instant)> = None;
 
@@ -132,6 +134,7 @@ fn run_loop(
                 theme,
                 file_browser.as_ref(),
                 show_eq,
+                show_lyrics,
                 visualizer_mode,
                 status_message.as_ref().map(|(msg, _)| msg.as_str()),
             )
@@ -392,6 +395,10 @@ fn run_loop(
                     };
                     None
                 }
+                KeyCode::Char('y') => {
+                    show_lyrics = !show_lyrics;
+                    None
+                }
                 _ => None,
             };
 
@@ -476,12 +483,14 @@ fn handle_action(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw(
     frame: &mut Frame,
     player: &Player,
     theme: &Theme,
     file_browser: Option<&FileBrowser>,
     show_eq: bool,
+    show_lyrics: bool,
     visualizer_mode: VisualizerMode,
     status_message: Option<&str>,
 ) {
@@ -502,11 +511,25 @@ fn draw(
         draw_eq_view(frame, chunks[1], player, theme);
         draw_eq_status_bar(frame, chunks[2], player, theme);
     } else {
-        match visualizer_mode {
-            VisualizerMode::Fullscreen => {
+        match (visualizer_mode, show_lyrics) {
+            (VisualizerMode::Fullscreen, _) => {
                 draw_visualizer(frame, chunks[1], player, theme);
             }
-            VisualizerMode::Normal => {
+            (VisualizerMode::Normal, true) => {
+                // Visualizer + lyrics: split right panel between playlist, lyrics, visualizer
+                let middle = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Percentage(40), // Playlist
+                        Constraint::Percentage(35), // Lyrics
+                        Constraint::Percentage(25), // Visualizer
+                    ])
+                    .split(chunks[1]);
+                draw_playlist(frame, middle[0], player, theme);
+                draw_lyrics(frame, middle[1], player, theme);
+                draw_visualizer(frame, middle[2], player, theme);
+            }
+            (VisualizerMode::Normal, false) => {
                 let middle = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([
@@ -517,7 +540,19 @@ fn draw(
                 draw_playlist(frame, middle[0], player, theme);
                 draw_visualizer(frame, middle[1], player, theme);
             }
-            VisualizerMode::Off => {
+            (VisualizerMode::Off, true) => {
+                // Lyrics replace the right side
+                let middle = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Percentage(50), // Playlist
+                        Constraint::Percentage(50), // Lyrics
+                    ])
+                    .split(chunks[1]);
+                draw_playlist(frame, middle[0], player, theme);
+                draw_lyrics(frame, middle[1], player, theme);
+            }
+            (VisualizerMode::Off, false) => {
                 draw_playlist(frame, chunks[1], player, theme);
             }
         }
@@ -681,6 +716,71 @@ fn draw_playlist(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) 
     frame.render_widget(list, area);
 }
 
+fn draw_lyrics(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.border)
+        .title(" Lyrics ")
+        .title_style(theme.title);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let current_lyrics = player.lyrics();
+    if current_lyrics.lines.is_empty() {
+        let msg = Paragraph::new(Line::from(Span::styled(
+            "  No lyrics found",
+            Style::default().fg(theme.dim),
+        )));
+        frame.render_widget(msg, inner);
+        return;
+    }
+
+    let position_ms = player.current_position().as_millis() as u64;
+    let current_idx = lyrics::current_line_index(current_lyrics, position_ms);
+
+    let visible_lines = inner.height as usize;
+    if visible_lines == 0 {
+        return;
+    }
+
+    let total = current_lyrics.lines.len();
+    let center = current_idx.unwrap_or(0);
+    let half = visible_lines / 2;
+    let start = center.saturating_sub(half);
+    let end = (start + visible_lines).min(total);
+    // Adjust start if we're near the end
+    let start = if end == total {
+        total.saturating_sub(visible_lines)
+    } else {
+        start
+    };
+
+    let lines: Vec<Line> = current_lyrics.lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, lyric)| {
+            let abs_idx = start + i;
+            let style = match current_idx {
+                Some(cur) if abs_idx == cur => Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+                Some(cur) if abs_idx < cur => Style::default().fg(theme.dim),
+                _ => Style::default().fg(theme.fg),
+            };
+            let text = if lyric.text.is_empty() {
+                "♪".to_string()
+            } else {
+                lyric.text.clone()
+            };
+            Line::from(Span::styled(format!(" {text}"), style))
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
 fn draw_status_bar(
     frame: &mut Frame,
     area: Rect,
@@ -713,6 +813,8 @@ fn draw_status_bar(
         Span::styled(":Repeat ", theme.help_text),
         Span::styled("v/V", theme.help_key),
         Span::styled(":Viz ", theme.help_text),
+        Span::styled("y", theme.help_key),
+        Span::styled(":Lyrics ", theme.help_text),
         Span::styled("[/]", theme.help_key),
         Span::styled(":Speed ", theme.help_text),
         Span::styled("S", theme.help_key),


### PR DESCRIPTION
## Description

Add synced lyrics display and AAC/ALAC format support — completing all Phase 3 (Audio Polish) features.

### What's included

- **Synced lyrics**: Press `y` to toggle a lyrics panel that auto-scrolls during playback. Current line is highlighted in accent color with bold, past lines dimmed, future lines in normal color. Lyrics are loaded from `.lrc` sidecar files (same name as audio file) or embedded tags (ID3v2 USLT, Vorbis LYRICS) via lofty. Robust LRC parser handles multiple timestamp formats, multi-timestamp lines, and metadata tags.
- **AAC/ALAC support**: Enabled symphonia's `aac`, `alac`, and `isomp4` features. M4A files with AAC or ALAC codecs now play natively without ffmpeg. Content-type mappings updated for HTTP streams (`audio/aac`, `audio/mp4`, `audio/alac`).
- **WMA error hint**: When a WMA file can't be decoded, the error message now suggests installing ffmpeg.
- **README updated**: Supported formats list now includes AAC and ALAC (M4A).

## Related Issues

Closes #24, closes #25

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `playback/` — Decode, DSP, state machine
- [x] `providers/` — Audio sources (local, radio, podcast)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (182 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)