### PR TITLE
feat: add OPML import/export and podcast subscription TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lyrics loaded from `.lrc` sidecar files or embedded tags (ID3v2 USLT, Vorbis LYRICS)
 - AAC and ALAC (M4A) format support via symphonia
 - Helpful error message when attempting to play WMA files (requires ffmpeg)
+- OPML import/export: `--import-opml <FILE>` and `--export-opml <FILE>` for podcast subscription portability
+- Podcast subscription management in TUI: press `P` to open podcast view
+- Add podcast feeds by URL, remove subscriptions, refresh feeds from within the TUI
+- Podcast episode browser with played/unplayed indicators, duration, and publish dates
 
 ### Changed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod tui;
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 
 use crate::core::track::Track;
@@ -64,6 +64,14 @@ struct Cli {
     /// Fetch a podcast RSS feed and play the most recent episode
     #[arg(long, value_name = "URL")]
     podcast: Option<String>,
+
+    /// Import podcast subscriptions from an OPML file
+    #[arg(long, value_name = "FILE")]
+    import_opml: Option<String>,
+
+    /// Export podcast subscriptions to an OPML file
+    #[arg(long, value_name = "FILE")]
+    export_opml: Option<String>,
 
     /// List available audio output devices and exit
     #[arg(long)]
@@ -119,6 +127,31 @@ fn main() -> Result<()> {
                 println!("  {}{marker}", d.name);
             }
         }
+        return Ok(());
+    }
+
+    // Handle --import-opml: read OPML file and import feeds into podcast state.
+    if let Some(ref opml_path) = cli.import_opml {
+        let content = std::fs::read_to_string(opml_path)
+            .with_context(|| format!("Failed to read OPML file: {opml_path}"))?;
+        let entries = providers::opml::import_opml(&content)?;
+        let total = entries.len();
+        let mut state = providers::podcast::load_state()?;
+        let added = state.import_feeds_from_opml(&entries);
+        providers::podcast::save_state(&state)?;
+        let skipped = total - added;
+        println!("Imported {added} new feed(s) ({skipped} already subscribed)");
+        return Ok(());
+    }
+
+    // Handle --export-opml: export podcast subscriptions to an OPML file.
+    if let Some(ref opml_path) = cli.export_opml {
+        let state = providers::podcast::load_state()?;
+        let feeds = state.export_feeds();
+        let xml = providers::opml::export_opml(feeds);
+        std::fs::write(opml_path, &xml)
+            .with_context(|| format!("Failed to write OPML file: {opml_path}"))?;
+        println!("Exported {} feed(s) to {opml_path}", feeds.len());
         return Ok(());
     }
 

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -96,6 +96,12 @@ pub enum PlayerCommand {
     #[allow(dead_code)] // Available for CLI/IPC device listing
     ListDevices,
     SetDevice(String),
+    /// Open the podcast browser view (handled in TUI layer).
+    #[allow(dead_code)]
+    OpenPodcasts,
+    /// Add a podcast feed by URL (handled in TUI layer).
+    #[allow(dead_code)]
+    AddPodcastFeed(String),
     Quit,
 }
 
@@ -627,6 +633,10 @@ impl Player {
             }
             PlayerCommand::SetDevice(name) => {
                 self.device_name = Some(name);
+                PlayerAction::None
+            }
+            PlayerCommand::OpenPodcasts | PlayerCommand::AddPodcastFeed(_) => {
+                // Handled in the TUI layer — no playback state change needed.
                 PlayerAction::None
             }
             PlayerCommand::Quit => PlayerAction::Quit,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod local;
+pub mod opml;
 pub mod podcast;
 pub mod radio;
 pub mod stations;

--- a/src/providers/opml.rs
+++ b/src/providers/opml.rs
@@ -1,0 +1,319 @@
+//! OPML import/export for podcast subscriptions.
+//!
+//! Parses and generates OPML 2.0 XML using simple string matching —
+//! no external XML crate needed.
+
+use anyhow::Result;
+
+use super::podcast::PodcastFeed;
+
+/// A single entry parsed from an OPML file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OpmlEntry {
+    pub title: String,
+    pub url: String,
+}
+
+/// Parse an OPML file and extract feed URLs.
+///
+/// Lenient: skips malformed outlines rather than failing the whole import.
+/// Handles both single and double quotes, nested outline groups, and
+/// outlines missing `xmlUrl` (which are treated as category folders).
+pub fn import_opml(content: &str) -> Result<Vec<OpmlEntry>> {
+    let mut entries = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("<outline") && !trimmed.starts_with("<Outline") {
+            // Also handle case-insensitive match
+            let lower = trimmed.to_lowercase();
+            if !lower.starts_with("<outline") {
+                continue;
+            }
+        }
+
+        let url = match extract_attr(trimmed, "xmlUrl")
+            .or_else(|| extract_attr(trimmed, "xmlurl"))
+            .or_else(|| extract_attr(trimmed, "XMLURL"))
+        {
+            Some(u) => u,
+            None => continue, // category folder or missing URL — skip
+        };
+
+        let title = extract_attr(trimmed, "text")
+            .or_else(|| extract_attr(trimmed, "title"))
+            .or_else(|| extract_attr(trimmed, "Text"))
+            .or_else(|| extract_attr(trimmed, "Title"))
+            .unwrap_or_default();
+
+        entries.push(OpmlEntry {
+            title: unescape_xml(&title),
+            url: unescape_xml(&url),
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Extract the value of an XML attribute from a tag string.
+///
+/// Handles both `attr="value"` and `attr='value'` forms.
+fn extract_attr(tag: &str, attr_name: &str) -> Option<String> {
+    // Build search pattern: `attrName="`  or  `attrName='`
+    for quote in ['"', '\''] {
+        let pattern = format!("{attr_name}={quote}");
+        if let Some(start) = tag.find(&pattern) {
+            let value_start = start + pattern.len();
+            if let Some(end) = tag[value_start..].find(quote) {
+                return Some(tag[value_start..value_start + end].to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Unescape basic XML entities.
+fn unescape_xml(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+/// Escape text for use in XML attribute values.
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Generate OPML 2.0 XML from a list of podcast feeds.
+pub fn export_opml(feeds: &[PodcastFeed]) -> String {
+    let mut xml = String::new();
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    xml.push_str("<opml version=\"2.0\">\n");
+    xml.push_str("  <head><title>kora Podcast Subscriptions</title></head>\n");
+    xml.push_str("  <body>\n");
+
+    for feed in feeds {
+        let text = escape_xml(&feed.title);
+        let url = escape_xml(&feed.url);
+        xml.push_str(&format!(
+            "    <outline text=\"{text}\" type=\"rss\" xmlUrl=\"{url}\" />\n"
+        ));
+    }
+
+    xml.push_str("  </body>\n");
+    xml.push_str("</opml>\n");
+    xml
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_opml_multiple_outlines() {
+        let opml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>My Podcasts</title></head>
+  <body>
+    <outline text="Podcast One" type="rss" xmlUrl="https://one.example.com/feed" />
+    <outline text="Podcast Two" type="rss" xmlUrl="https://two.example.com/rss.xml" />
+    <outline text="Podcast Three" type="rss" xmlUrl="https://three.example.com/feed.xml" />
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].title, "Podcast One");
+        assert_eq!(entries[0].url, "https://one.example.com/feed");
+        assert_eq!(entries[1].title, "Podcast Two");
+        assert_eq!(entries[2].url, "https://three.example.com/feed.xml");
+    }
+
+    #[test]
+    fn parse_nested_outline_groups() {
+        let opml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Nested</title></head>
+  <body>
+    <outline text="Tech">
+      <outline text="Tech Pod" type="rss" xmlUrl="https://tech.example.com/rss" />
+    </outline>
+    <outline text="Comedy">
+      <outline text="Funny Show" type="rss" xmlUrl="https://funny.example.com/rss" />
+      <outline text="Laughs" type="rss" xmlUrl="https://laughs.example.com/rss" />
+    </outline>
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        // Category folders (no xmlUrl) are skipped, only feeds are returned
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].title, "Tech Pod");
+        assert_eq!(entries[1].title, "Funny Show");
+        assert_eq!(entries[2].title, "Laughs");
+    }
+
+    #[test]
+    fn parse_single_quotes() {
+        let opml = r#"<?xml version='1.0'?>
+<opml version='2.0'>
+  <body>
+    <outline text='Single Quoted' type='rss' xmlUrl='https://single.example.com/feed' />
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Single Quoted");
+        assert_eq!(entries[0].url, "https://single.example.com/feed");
+    }
+
+    #[test]
+    fn parse_empty_opml_returns_empty() {
+        let opml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Empty</title></head>
+  <body>
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_non_xml_returns_empty() {
+        let garbage = "this is not xml at all\njust random text\n{\"json\": true}";
+        let entries = import_opml(garbage).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_string_returns_empty() {
+        let entries = import_opml("").unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn export_produces_valid_xml() {
+        let feeds = vec![
+            PodcastFeed {
+                url: "https://example.com/feed1".to_string(),
+                title: "Feed One".to_string(),
+                description: String::new(),
+            },
+            PodcastFeed {
+                url: "https://example.com/feed2".to_string(),
+                title: "Feed Two".to_string(),
+                description: "A great podcast".to_string(),
+            },
+        ];
+
+        let xml = export_opml(&feeds);
+        assert!(xml.contains("<?xml version=\"1.0\""));
+        assert!(xml.contains("<opml version=\"2.0\">"));
+        assert!(xml.contains("xmlUrl=\"https://example.com/feed1\""));
+        assert!(xml.contains("text=\"Feed One\""));
+        assert!(xml.contains("xmlUrl=\"https://example.com/feed2\""));
+        assert!(xml.contains("text=\"Feed Two\""));
+        assert!(xml.contains("type=\"rss\""));
+    }
+
+    #[test]
+    fn export_escapes_xml_entities() {
+        let feeds = vec![PodcastFeed {
+            url: "https://example.com/feed?a=1&b=2".to_string(),
+            title: "Tom & Jerry's <Show>".to_string(),
+            description: String::new(),
+        }];
+
+        let xml = export_opml(&feeds);
+        assert!(xml.contains("Tom &amp; Jerry's &lt;Show&gt;"));
+        assert!(xml.contains("a=1&amp;b=2"));
+    }
+
+    #[test]
+    fn round_trip_export_import_preserves_feeds() {
+        let feeds = vec![
+            PodcastFeed {
+                url: "https://alpha.example.com/rss".to_string(),
+                title: "Alpha Pod".to_string(),
+                description: String::new(),
+            },
+            PodcastFeed {
+                url: "https://beta.example.com/feed.xml".to_string(),
+                title: "Beta Show".to_string(),
+                description: "desc".to_string(),
+            },
+        ];
+
+        let xml = export_opml(&feeds);
+        let entries = import_opml(&xml).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].title, "Alpha Pod");
+        assert_eq!(entries[0].url, "https://alpha.example.com/rss");
+        assert_eq!(entries[1].title, "Beta Show");
+        assert_eq!(entries[1].url, "https://beta.example.com/feed.xml");
+    }
+
+    #[test]
+    fn round_trip_with_special_chars() {
+        let feeds = vec![PodcastFeed {
+            url: "https://example.com/rss?format=xml&lang=en".to_string(),
+            title: "A & B \"Podcast\" <Special>".to_string(),
+            description: String::new(),
+        }];
+
+        let xml = export_opml(&feeds);
+        let entries = import_opml(&xml).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "A & B \"Podcast\" <Special>");
+        assert_eq!(entries[0].url, "https://example.com/rss?format=xml&lang=en");
+    }
+
+    #[test]
+    fn import_skips_outlines_without_xml_url() {
+        let opml = r#"<opml version="2.0">
+  <body>
+    <outline text="Category Folder" />
+    <outline text="Real Feed" type="rss" xmlUrl="https://real.example.com/rss" />
+    <outline text="Another Category">
+    </outline>
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Real Feed");
+    }
+
+    #[test]
+    fn import_handles_mixed_case_attributes() {
+        let opml = r#"<opml version="2.0">
+  <body>
+    <outline text="Mixed Case" type="rss" xmlUrl="https://mixed.example.com/feed" />
+  </body>
+</opml>"#;
+
+        let entries = import_opml(opml).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].url, "https://mixed.example.com/feed");
+    }
+
+    #[test]
+    fn export_empty_feeds() {
+        let xml = export_opml(&[]);
+        assert!(xml.contains("<body>"));
+        assert!(xml.contains("</body>"));
+        // Should still be valid OPML, just with no outlines
+        let entries = import_opml(&xml).unwrap();
+        assert!(entries.is_empty());
+    }
+}

--- a/src/providers/podcast.rs
+++ b/src/providers/podcast.rs
@@ -34,7 +34,7 @@ pub struct PodcastEpisode {
 }
 
 /// Persisted podcast state (subscriptions + resume positions).
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[allow(dead_code)] // Public API — used by future TUI podcast management
 pub struct PodcastState {
     #[serde(default)]
@@ -42,6 +42,31 @@ pub struct PodcastState {
     /// Map of audio URL → last playback position in ms.
     #[serde(default)]
     pub episode_positions: HashMap<String, u64>,
+}
+
+impl PodcastState {
+    /// Import feeds from OPML entries, deduplicating by URL.
+    /// Returns the number of newly added feeds.
+    pub fn import_feeds_from_opml(&mut self, entries: &[super::opml::OpmlEntry]) -> usize {
+        let mut added = 0;
+        for entry in entries {
+            let already_exists = self.feeds.iter().any(|f| f.url == entry.url);
+            if !already_exists {
+                self.feeds.push(PodcastFeed {
+                    url: entry.url.clone(),
+                    title: entry.title.clone(),
+                    description: String::new(),
+                });
+                added += 1;
+            }
+        }
+        added
+    }
+
+    /// Return all subscribed feeds (convenience accessor for OPML export).
+    pub fn export_feeds(&self) -> &[PodcastFeed] {
+        &self.feeds
+    }
 }
 
 /// Fetch an RSS feed and parse it into a `PodcastFeed` + episode list.
@@ -390,5 +415,62 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn import_feeds_deduplicates_by_url() {
+        let mut state = PodcastState {
+            feeds: vec![PodcastFeed {
+                url: "https://existing.example.com/rss".to_string(),
+                title: "Existing Pod".to_string(),
+                description: String::new(),
+            }],
+            episode_positions: HashMap::new(),
+        };
+
+        let entries = vec![
+            super::super::opml::OpmlEntry {
+                title: "New Feed".to_string(),
+                url: "https://new.example.com/rss".to_string(),
+            },
+            super::super::opml::OpmlEntry {
+                title: "Existing Pod (dupe)".to_string(),
+                url: "https://existing.example.com/rss".to_string(),
+            },
+            super::super::opml::OpmlEntry {
+                title: "Another New".to_string(),
+                url: "https://another.example.com/rss".to_string(),
+            },
+        ];
+
+        let added = state.import_feeds_from_opml(&entries);
+        assert_eq!(added, 2);
+        assert_eq!(state.feeds.len(), 3);
+        // Original title preserved for the duplicate
+        assert_eq!(state.feeds[0].title, "Existing Pod");
+    }
+
+    #[test]
+    fn export_feeds_returns_all() {
+        let state = PodcastState {
+            feeds: vec![
+                PodcastFeed {
+                    url: "https://a.com/rss".to_string(),
+                    title: "A".to_string(),
+                    description: String::new(),
+                },
+                PodcastFeed {
+                    url: "https://b.com/rss".to_string(),
+                    title: "B".to_string(),
+                    description: String::new(),
+                },
+            ],
+            episode_positions: HashMap::new(),
+        };
+
+        let feeds = state.export_feeds();
+        assert_eq!(feeds.len(), 2);
+        assert_eq!(feeds[0].title, "A");
+        assert_eq!(feeds[1].title, "B");
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -297,16 +297,14 @@ fn run_loop(
                         }
                     } else {
                         match key.code {
-                            KeyCode::Esc => {
-                                if pv.back() {
-                                    close_podcast = true;
-                                }
+                            KeyCode::Esc if pv.back() => {
+                                close_podcast = true;
                             }
-                            KeyCode::Backspace => {
-                                if pv.back() {
-                                    close_podcast = true;
-                                }
+                            KeyCode::Esc => {}
+                            KeyCode::Backspace if pv.back() => {
+                                close_podcast = true;
                             }
+                            KeyCode::Backspace => {}
                             KeyCode::Char('j') | KeyCode::Down => pv.select_down(),
                             KeyCode::Char('k') | KeyCode::Up => pv.select_up(),
                             KeyCode::Enter => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,6 +17,7 @@ use ratatui::widgets::{Block, Borders, Clear, Gauge, List, ListItem, Paragraph};
 use ratatui::{DefaultTerminal, Frame};
 
 use super::file_browser::FileBrowser;
+use super::podcast_view::{InputMode, PodcastView, PodcastViewMode};
 use super::theme::{self, Theme};
 use crate::core::session::Session;
 use crate::core::track::Track;
@@ -116,6 +117,7 @@ fn run_loop(
     let save_interval = Duration::from_secs(30);
     let mut last_save = Instant::now();
     let mut file_browser: Option<FileBrowser> = None;
+    let mut podcast_view: Option<PodcastView> = None;
     let mut show_eq = false;
     let mut show_lyrics = false;
     let mut visualizer_mode = VisualizerMode::Normal;
@@ -133,6 +135,7 @@ fn run_loop(
                 player,
                 theme,
                 file_browser.as_ref(),
+                podcast_view.as_ref(),
                 show_eq,
                 show_lyrics,
                 visualizer_mode,
@@ -277,6 +280,85 @@ fn run_loop(
                 continue;
             }
 
+            // Podcast view input handling (takes priority when open)
+            if podcast_view.is_some() {
+                let mut close_podcast = false;
+                let mut play_episode = false;
+
+                if let Some(ref mut pv) = podcast_view {
+                    // Text input mode for adding a feed URL
+                    if pv.input_mode() == InputMode::AddingFeed {
+                        match key.code {
+                            KeyCode::Esc => pv.cancel_input(),
+                            KeyCode::Enter => pv.submit_input(),
+                            KeyCode::Backspace => pv.input_backspace(),
+                            KeyCode::Char(c) => pv.input_char(c),
+                            _ => {}
+                        }
+                    } else {
+                        match key.code {
+                            KeyCode::Esc => {
+                                if pv.back() {
+                                    close_podcast = true;
+                                }
+                            }
+                            KeyCode::Backspace => {
+                                if pv.back() {
+                                    close_podcast = true;
+                                }
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => pv.select_down(),
+                            KeyCode::Char('k') | KeyCode::Up => pv.select_up(),
+                            KeyCode::Enter => {
+                                play_episode = pv.enter();
+                            }
+                            KeyCode::Char('a') => pv.start_add_feed(),
+                            KeyCode::Char('x') | KeyCode::Delete => {
+                                let idx = pv.selected_feed_index();
+                                if pv.mode() == PodcastViewMode::FeedList {
+                                    pv.remove_feed(idx);
+                                }
+                            }
+                            KeyCode::Char('R') => {
+                                if pv.mode() == PodcastViewMode::EpisodeList {
+                                    let idx = pv.selected_feed_index();
+                                    pv.refresh_feed(idx);
+                                } else {
+                                    pv.refresh_all();
+                                }
+                            }
+                            KeyCode::Char('q') => {
+                                if let Err(e) = player.save_session() {
+                                    tracing::warn!("Failed to save session on quit: {e}");
+                                }
+                                return Ok(());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                if play_episode
+                    && let Some(ref pv) = podcast_view
+                    && let Some(track) = pv.selected_episode_track()
+                {
+                    let action = player.add_and_play(track);
+                    handle_action(
+                        action,
+                        player,
+                        playback_handle,
+                        &mut gapless_played_next,
+                        &mut pre_decode_triggered,
+                    )?;
+                }
+
+                if close_podcast {
+                    podcast_view = None;
+                }
+
+                continue;
+            }
+
             // EQ view input handling
             if show_eq {
                 let cmd = match key.code {
@@ -372,6 +454,13 @@ fn run_loop(
                         .and_then(|c| c.music_dir)
                         .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")));
                     file_browser = Some(FileBrowser::new(start_dir));
+                    None
+                }
+                KeyCode::Char('P') => {
+                    let state = crate::providers::podcast::load_state().unwrap_or_default();
+                    let mut pv = PodcastView::new(&state);
+                    pv.ensure_refreshed();
+                    podcast_view = Some(pv);
                     None
                 }
                 KeyCode::Char('f') => Some(PlayerCommand::ToggleFavorite),
@@ -489,6 +578,7 @@ fn draw(
     player: &Player,
     theme: &Theme,
     file_browser: Option<&FileBrowser>,
+    podcast_view: Option<&PodcastView>,
     show_eq: bool,
     show_lyrics: bool,
     visualizer_mode: VisualizerMode,
@@ -562,6 +652,11 @@ fn draw(
     // File browser overlay
     if let Some(browser) = file_browser {
         draw_file_browser(frame, area, browser, theme);
+    }
+
+    // Podcast view overlay
+    if let Some(pv) = podcast_view {
+        draw_podcast_view(frame, area, pv, theme);
     }
 }
 
@@ -805,6 +900,8 @@ fn draw_status_bar(
         Span::styled(":Theme ", theme.help_text),
         Span::styled("o", theme.help_key),
         Span::styled(":Browse ", theme.help_text),
+        Span::styled("P", theme.help_key),
+        Span::styled(":Podcast ", theme.help_text),
         Span::styled("f", theme.help_key),
         Span::styled(":Fav ", theme.help_text),
         Span::styled("z", theme.help_key),
@@ -1161,6 +1258,218 @@ fn draw_file_browser(frame: &mut Frame, area: Rect, browser: &FileBrowser, theme
 
     let list = List::new(items);
     frame.render_widget(list, inner);
+}
+
+fn draw_podcast_view(frame: &mut Frame, area: Rect, pv: &PodcastView, theme: &Theme) {
+    let popup_area = centered_rect(80, 80, area);
+
+    // Clear the area behind the popup
+    frame.render_widget(Clear, popup_area);
+
+    // Reserve bottom row for help bar (and input bar when adding)
+    let input_active = pv.input_mode() == InputMode::AddingFeed;
+    let bottom_rows = if input_active { 2 } else { 1 };
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(bottom_rows)])
+        .split(popup_area);
+
+    let content_area = layout[0];
+    let bottom_area = layout[1];
+
+    match pv.mode() {
+        PodcastViewMode::FeedList => {
+            let title = if let Some(msg) = pv.status_message() {
+                format!(" Podcasts — {msg} ")
+            } else {
+                " Podcasts ".to_string()
+            };
+
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme.border)
+                .title(title)
+                .title_style(theme.title);
+
+            let inner = block.inner(content_area);
+            frame.render_widget(block, content_area);
+
+            let feeds = pv.feeds();
+            if feeds.is_empty() {
+                let msg = Paragraph::new(Line::from(Span::styled(
+                    "  No podcasts subscribed. Press 'a' to add a feed.",
+                    theme.status_info,
+                )));
+                frame.render_widget(msg, inner);
+            } else {
+                let visible_height = inner.height as usize;
+                let scroll = pv.scroll_offset();
+                let end = (scroll + visible_height).min(feeds.len());
+
+                let items: Vec<ListItem> = feeds[scroll..end]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, entry)| {
+                        let idx = scroll + i;
+                        let is_selected = idx == pv.selected_feed_index();
+                        let prefix = if is_selected { "▶ " } else { "  " };
+                        let ep_count = if entry.episode_count > 0 {
+                            format!(" ({} eps)", entry.episode_count)
+                        } else {
+                            String::new()
+                        };
+                        let style = if is_selected {
+                            theme.playlist_current
+                        } else {
+                            theme.playlist_normal
+                        };
+                        ListItem::new(Line::from(Span::styled(
+                            format!("{prefix}{}{ep_count}", entry.feed.title),
+                            style,
+                        )))
+                    })
+                    .collect();
+
+                let list = List::new(items);
+                frame.render_widget(list, inner);
+            }
+        }
+        PodcastViewMode::EpisodeList => {
+            let feed_title = pv
+                .feeds()
+                .get(pv.selected_feed_index())
+                .map(|f| f.feed.title.as_str())
+                .unwrap_or("Unknown");
+
+            let title = if let Some(msg) = pv.status_message() {
+                format!(" {feed_title} — {msg} ")
+            } else {
+                format!(" {feed_title} ")
+            };
+
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme.border)
+                .title(title)
+                .title_style(theme.title);
+
+            let inner = block.inner(content_area);
+            frame.render_widget(block, content_area);
+
+            if let Some(feed_entry) = pv.feeds().get(pv.selected_feed_index()) {
+                let episodes = &feed_entry.episodes;
+                if episodes.is_empty() {
+                    let msg = Paragraph::new(Line::from(Span::styled(
+                        "  No episodes found",
+                        theme.status_info,
+                    )));
+                    frame.render_widget(msg, inner);
+                } else {
+                    let visible_height = inner.height as usize;
+                    let scroll = pv.scroll_offset();
+                    let end = (scroll + visible_height).min(episodes.len());
+
+                    let items: Vec<ListItem> = episodes[scroll..end]
+                        .iter()
+                        .enumerate()
+                        .map(|(i, ep)| {
+                            let idx = scroll + i;
+                            let is_selected = idx == pv.selected_episode_index();
+                            let prefix = if is_selected { "▶ " } else { "  " };
+                            let played_icon = if ep.played { "✓ " } else { "  " };
+                            let duration_str = ep
+                                .duration_secs
+                                .map(|s| {
+                                    let mins = s / 60;
+                                    let secs = s % 60;
+                                    format!(" [{mins}:{secs:02}]")
+                                })
+                                .unwrap_or_default();
+                            let date_str = ep
+                                .published
+                                .as_ref()
+                                .map(|d| {
+                                    // Show a short date prefix
+                                    let short = if d.len() > 16 { &d[..16] } else { d };
+                                    format!(" ({short})")
+                                })
+                                .unwrap_or_default();
+                            let style = if is_selected {
+                                theme.playlist_current
+                            } else if ep.played {
+                                theme.status_info
+                            } else {
+                                theme.playlist_normal
+                            };
+                            ListItem::new(Line::from(Span::styled(
+                                format!(
+                                    "{prefix}{played_icon}{}{duration_str}{date_str}",
+                                    ep.title
+                                ),
+                                style,
+                            )))
+                        })
+                        .collect();
+
+                    let list = List::new(items);
+                    frame.render_widget(list, inner);
+                }
+            }
+        }
+    }
+
+    // Bottom area: input bar and/or help bar
+    if input_active {
+        let input_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Length(1)])
+            .split(bottom_area);
+
+        let input_line = Line::from(vec![
+            Span::styled(" Feed URL: ", theme.title),
+            Span::styled(pv.input_buffer(), theme.track_title),
+            Span::styled("█", theme.playlist_current),
+        ]);
+        frame.render_widget(Paragraph::new(input_line), input_layout[0]);
+
+        let help = Line::from(vec![
+            Span::styled("Enter", theme.help_key),
+            Span::styled(":Submit ", theme.help_text),
+            Span::styled("Esc", theme.help_key),
+            Span::styled(":Cancel", theme.help_text),
+        ]);
+        frame.render_widget(Paragraph::new(help), input_layout[1]);
+    } else {
+        let help_spans = match pv.mode() {
+            PodcastViewMode::FeedList => vec![
+                Span::styled("j/k", theme.help_key),
+                Span::styled(":Navigate ", theme.help_text),
+                Span::styled("Enter", theme.help_key),
+                Span::styled(":Episodes ", theme.help_text),
+                Span::styled("a", theme.help_key),
+                Span::styled(":Add Feed ", theme.help_text),
+                Span::styled("x", theme.help_key),
+                Span::styled(":Remove ", theme.help_text),
+                Span::styled("R", theme.help_key),
+                Span::styled(":Refresh All ", theme.help_text),
+                Span::styled("Esc", theme.help_key),
+                Span::styled(":Close", theme.help_text),
+            ],
+            PodcastViewMode::EpisodeList => vec![
+                Span::styled("j/k", theme.help_key),
+                Span::styled(":Navigate ", theme.help_text),
+                Span::styled("Enter", theme.help_key),
+                Span::styled(":Play ", theme.help_text),
+                Span::styled("R", theme.help_key),
+                Span::styled(":Refresh ", theme.help_text),
+                Span::styled("Bksp/Esc", theme.help_key),
+                Span::styled(":Back", theme.help_text),
+            ],
+        };
+        let help = Line::from(help_spans);
+        frame.render_widget(Paragraph::new(help), bottom_area);
+    }
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod file_browser;
+pub mod podcast_view;
 pub mod theme;

--- a/src/tui/podcast_view.rs
+++ b/src/tui/podcast_view.rs
@@ -1,0 +1,517 @@
+//! Podcast browser overlay — browse subscribed feeds and their episodes.
+
+use crate::core::track::Track;
+use crate::providers::podcast::{
+    PodcastEpisode, PodcastFeed, PodcastState, episode_to_track, fetch_feed, save_state,
+};
+
+/// A feed bundled with its fetched episodes.
+pub struct PodcastFeedWithEpisodes {
+    pub feed: PodcastFeed,
+    pub episodes: Vec<PodcastEpisode>,
+    pub episode_count: usize,
+}
+
+/// Current browsing mode inside the podcast view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PodcastViewMode {
+    /// Browsing the list of subscribed feeds.
+    FeedList,
+    /// Browsing episodes within a selected feed.
+    EpisodeList,
+}
+
+/// Input mode for text entry (adding a feed URL).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    Normal,
+    /// Typing a feed URL.
+    AddingFeed,
+}
+
+/// Podcast browser component for the TUI overlay.
+pub struct PodcastView {
+    feeds: Vec<PodcastFeedWithEpisodes>,
+    selected_feed: usize,
+    selected_episode: usize,
+    mode: PodcastViewMode,
+    status_message: Option<String>,
+    input_mode: InputMode,
+    input_buffer: String,
+    scroll_offset: usize,
+    visible_height: usize,
+    /// The underlying podcast state for persistence.
+    state: PodcastState,
+    /// Whether feeds have been refreshed at least once since opening.
+    refreshed: bool,
+}
+
+impl PodcastView {
+    /// Initialize from saved podcast state.
+    pub fn new(state: &PodcastState) -> Self {
+        let feeds: Vec<PodcastFeedWithEpisodes> = state
+            .feeds
+            .iter()
+            .map(|f| PodcastFeedWithEpisodes {
+                feed: f.clone(),
+                episodes: Vec::new(),
+                episode_count: 0,
+            })
+            .collect();
+
+        Self {
+            feeds,
+            selected_feed: 0,
+            selected_episode: 0,
+            mode: PodcastViewMode::FeedList,
+            status_message: None,
+            input_mode: InputMode::Normal,
+            input_buffer: String::new(),
+            scroll_offset: 0,
+            visible_height: 20,
+            state: state.clone(),
+            refreshed: false,
+        }
+    }
+
+    /// Lazy-refresh all feeds on first open.
+    pub fn ensure_refreshed(&mut self) {
+        if !self.refreshed {
+            self.refreshed = true;
+            self.refresh_all();
+        }
+    }
+
+    /// Re-fetch the RSS feed at the given index.
+    pub fn refresh_feed(&mut self, index: usize) {
+        if let Some(entry) = self.feeds.get_mut(index) {
+            match fetch_feed(&entry.feed.url) {
+                Ok((feed, episodes)) => {
+                    entry.episode_count = episodes.len();
+                    entry.episodes = episodes;
+                    entry.feed.title = feed.title;
+                    entry.feed.description = feed.description;
+                    // Restore played/position state from persisted data
+                    for ep in &mut entry.episodes {
+                        if let Some(&pos) = self.state.episode_positions.get(&ep.audio_url) {
+                            ep.position_ms = pos;
+                            if pos > 0 {
+                                ep.played = true;
+                            }
+                        }
+                    }
+                    self.status_message = Some(format!("Refreshed: {}", entry.feed.title));
+                    // Sync feed title back to state
+                    if let Some(sf) = self.state.feeds.get_mut(index) {
+                        sf.title = entry.feed.title.clone();
+                        sf.description = entry.feed.description.clone();
+                    }
+                }
+                Err(e) => {
+                    self.status_message = Some(format!("Error: {e}"));
+                }
+            }
+        }
+    }
+
+    /// Refresh all subscribed feeds.
+    pub fn refresh_all(&mut self) {
+        let count = self.feeds.len();
+        if count == 0 {
+            self.status_message = Some("No feeds to refresh".to_string());
+            return;
+        }
+        self.status_message = Some("Refreshing all feeds...".to_string());
+        for i in 0..count {
+            self.refresh_feed(i);
+        }
+        self.status_message = Some(format!("Refreshed {count} feed(s)"));
+    }
+
+    /// Add a new feed by URL — fetches, parses, and appends.
+    pub fn add_feed(&mut self, url: &str) {
+        // Check for duplicate
+        if self.feeds.iter().any(|f| f.feed.url == url) {
+            self.status_message = Some("Feed already subscribed".to_string());
+            return;
+        }
+
+        self.status_message = Some("Fetching feed...".to_string());
+        match fetch_feed(url) {
+            Ok((feed, episodes)) => {
+                let episode_count = episodes.len();
+                let title = feed.title.clone();
+                self.feeds.push(PodcastFeedWithEpisodes {
+                    feed: feed.clone(),
+                    episodes,
+                    episode_count,
+                });
+                self.state.feeds.push(feed);
+                if let Err(e) = save_state(&self.state) {
+                    tracing::warn!("Failed to save podcast state: {e}");
+                }
+                self.status_message = Some(format!("Added: {title}"));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Error: {e}"));
+            }
+        }
+    }
+
+    /// Remove the feed at the given index.
+    pub fn remove_feed(&mut self, index: usize) {
+        if index < self.feeds.len() {
+            let title = self.feeds[index].feed.title.clone();
+            self.feeds.remove(index);
+            self.state.feeds.remove(index);
+            if let Err(e) = save_state(&self.state) {
+                tracing::warn!("Failed to save podcast state: {e}");
+            }
+            // Clamp selection
+            if self.selected_feed >= self.feeds.len() && !self.feeds.is_empty() {
+                self.selected_feed = self.feeds.len() - 1;
+            }
+            self.status_message = Some(format!("Removed: {title}"));
+        }
+    }
+
+    /// Convert the selected episode to a playable Track.
+    pub fn selected_episode_track(&self) -> Option<Track> {
+        if self.mode != PodcastViewMode::EpisodeList {
+            return None;
+        }
+        let feed = self.feeds.get(self.selected_feed)?;
+        let episode = feed.episodes.get(self.selected_episode)?;
+        Some(episode_to_track(episode))
+    }
+
+    /// Move selection up.
+    pub fn select_up(&mut self) {
+        match self.mode {
+            PodcastViewMode::FeedList => {
+                if self.selected_feed > 0 {
+                    self.selected_feed -= 1;
+                    self.adjust_scroll();
+                }
+            }
+            PodcastViewMode::EpisodeList => {
+                if self.selected_episode > 0 {
+                    self.selected_episode -= 1;
+                    self.adjust_scroll();
+                }
+            }
+        }
+    }
+
+    /// Move selection down.
+    pub fn select_down(&mut self) {
+        match self.mode {
+            PodcastViewMode::FeedList => {
+                if !self.feeds.is_empty() && self.selected_feed + 1 < self.feeds.len() {
+                    self.selected_feed += 1;
+                    self.adjust_scroll();
+                }
+            }
+            PodcastViewMode::EpisodeList => {
+                if let Some(feed) = self.feeds.get(self.selected_feed)
+                    && !feed.episodes.is_empty()
+                    && self.selected_episode + 1 < feed.episodes.len()
+                {
+                    self.selected_episode += 1;
+                    self.adjust_scroll();
+                }
+            }
+        }
+    }
+
+    /// Enter: drill into feed (show episodes) or select episode for playback.
+    /// Returns `true` if an episode was selected (caller should play it).
+    pub fn enter(&mut self) -> bool {
+        match self.mode {
+            PodcastViewMode::FeedList => {
+                if !self.feeds.is_empty() {
+                    self.mode = PodcastViewMode::EpisodeList;
+                    self.selected_episode = 0;
+                    self.scroll_offset = 0;
+                }
+                false
+            }
+            PodcastViewMode::EpisodeList => {
+                // Signal that an episode was selected
+                self.selected_episode_track().is_some()
+            }
+        }
+    }
+
+    /// Go back: from episodes to feed list, or signal close.
+    /// Returns `true` if the view should be closed.
+    pub fn back(&mut self) -> bool {
+        match self.mode {
+            PodcastViewMode::EpisodeList => {
+                self.mode = PodcastViewMode::FeedList;
+                self.scroll_offset = 0;
+                false
+            }
+            PodcastViewMode::FeedList => true,
+        }
+    }
+
+    /// Start the add-feed text input mode.
+    pub fn start_add_feed(&mut self) {
+        self.input_mode = InputMode::AddingFeed;
+        self.input_buffer.clear();
+    }
+
+    /// Cancel text input.
+    pub fn cancel_input(&mut self) {
+        self.input_mode = InputMode::Normal;
+        self.input_buffer.clear();
+    }
+
+    /// Submit the current input buffer as a feed URL.
+    pub fn submit_input(&mut self) {
+        if self.input_mode == InputMode::AddingFeed && !self.input_buffer.is_empty() {
+            let url = self.input_buffer.clone();
+            self.input_mode = InputMode::Normal;
+            self.input_buffer.clear();
+            self.add_feed(&url);
+        } else {
+            self.input_mode = InputMode::Normal;
+            self.input_buffer.clear();
+        }
+    }
+
+    /// Append a character to the input buffer.
+    pub fn input_char(&mut self, c: char) {
+        self.input_buffer.push(c);
+    }
+
+    /// Delete the last character from the input buffer.
+    pub fn input_backspace(&mut self) {
+        self.input_buffer.pop();
+    }
+
+    // --- Accessors for rendering ---
+
+    pub fn feeds(&self) -> &[PodcastFeedWithEpisodes] {
+        &self.feeds
+    }
+
+    pub fn selected_feed_index(&self) -> usize {
+        self.selected_feed
+    }
+
+    pub fn selected_episode_index(&self) -> usize {
+        self.selected_episode
+    }
+
+    pub fn mode(&self) -> PodcastViewMode {
+        self.mode
+    }
+
+    pub fn status_message(&self) -> Option<&str> {
+        self.status_message.as_deref()
+    }
+
+    pub fn input_mode(&self) -> InputMode {
+        self.input_mode
+    }
+
+    pub fn input_buffer(&self) -> &str {
+        &self.input_buffer
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    #[allow(dead_code)] // Used for future resize handling and dead_code lint
+    pub fn set_visible_height(&mut self, height: usize) {
+        self.visible_height = height;
+    }
+
+    fn selected_index(&self) -> usize {
+        match self.mode {
+            PodcastViewMode::FeedList => self.selected_feed,
+            PodcastViewMode::EpisodeList => self.selected_episode,
+        }
+    }
+
+    fn adjust_scroll(&mut self) {
+        if self.visible_height == 0 {
+            return;
+        }
+        let sel = self.selected_index();
+        if sel < self.scroll_offset {
+            self.scroll_offset = sel;
+        } else if sel >= self.scroll_offset + self.visible_height {
+            self.scroll_offset = sel - self.visible_height + 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn empty_state() -> PodcastState {
+        PodcastState::default()
+    }
+
+    fn state_with_feeds() -> PodcastState {
+        PodcastState {
+            feeds: vec![
+                PodcastFeed {
+                    url: "https://example.com/feed1.rss".to_string(),
+                    title: "Feed One".to_string(),
+                    description: "First feed".to_string(),
+                },
+                PodcastFeed {
+                    url: "https://example.com/feed2.rss".to_string(),
+                    title: "Feed Two".to_string(),
+                    description: "Second feed".to_string(),
+                },
+                PodcastFeed {
+                    url: "https://example.com/feed3.rss".to_string(),
+                    title: "Feed Three".to_string(),
+                    description: "Third feed".to_string(),
+                },
+            ],
+            episode_positions: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn new_with_empty_state() {
+        let view = PodcastView::new(&empty_state());
+        assert!(view.feeds().is_empty());
+        assert_eq!(view.selected_feed_index(), 0);
+        assert_eq!(view.selected_episode_index(), 0);
+        assert_eq!(view.mode(), PodcastViewMode::FeedList);
+        assert!(view.status_message().is_none());
+        assert_eq!(view.input_mode(), InputMode::Normal);
+    }
+
+    #[test]
+    fn new_loads_feeds_from_state() {
+        let state = state_with_feeds();
+        let view = PodcastView::new(&state);
+        assert_eq!(view.feeds().len(), 3);
+        assert_eq!(view.feeds()[0].feed.title, "Feed One");
+        assert_eq!(view.feeds()[1].feed.title, "Feed Two");
+        assert_eq!(view.feeds()[2].feed.title, "Feed Three");
+        // Episodes are empty until refresh
+        assert!(view.feeds()[0].episodes.is_empty());
+    }
+
+    #[test]
+    fn navigation_clamps_at_boundaries() {
+        let state = state_with_feeds();
+        let mut view = PodcastView::new(&state);
+
+        // Already at 0 — up should stay at 0
+        view.select_up();
+        assert_eq!(view.selected_feed_index(), 0);
+
+        // Go to end
+        view.select_down();
+        view.select_down();
+        assert_eq!(view.selected_feed_index(), 2);
+
+        // Down past end should clamp
+        view.select_down();
+        assert_eq!(view.selected_feed_index(), 2);
+    }
+
+    #[test]
+    fn navigation_up_down() {
+        let state = state_with_feeds();
+        let mut view = PodcastView::new(&state);
+
+        assert_eq!(view.selected_feed_index(), 0);
+        view.select_down();
+        assert_eq!(view.selected_feed_index(), 1);
+        view.select_down();
+        assert_eq!(view.selected_feed_index(), 2);
+        view.select_up();
+        assert_eq!(view.selected_feed_index(), 1);
+        view.select_up();
+        assert_eq!(view.selected_feed_index(), 0);
+    }
+
+    #[test]
+    fn mode_switches_on_enter_and_back() {
+        let state = state_with_feeds();
+        let mut view = PodcastView::new(&state);
+
+        assert_eq!(view.mode(), PodcastViewMode::FeedList);
+
+        // Enter drills into episodes
+        let played = view.enter();
+        assert!(!played);
+        assert_eq!(view.mode(), PodcastViewMode::EpisodeList);
+
+        // Back returns to feed list
+        let should_close = view.back();
+        assert!(!should_close);
+        assert_eq!(view.mode(), PodcastViewMode::FeedList);
+
+        // Back again in feed list means close
+        let should_close = view.back();
+        assert!(should_close);
+    }
+
+    #[test]
+    fn enter_on_empty_feed_list_stays_in_feed_list() {
+        let mut view = PodcastView::new(&empty_state());
+        let played = view.enter();
+        assert!(!played);
+        assert_eq!(view.mode(), PodcastViewMode::FeedList);
+    }
+
+    #[test]
+    fn input_mode_add_feed() {
+        let mut view = PodcastView::new(&empty_state());
+
+        view.start_add_feed();
+        assert_eq!(view.input_mode(), InputMode::AddingFeed);
+        assert!(view.input_buffer().is_empty());
+
+        view.input_char('h');
+        view.input_char('t');
+        view.input_char('t');
+        view.input_char('p');
+        assert_eq!(view.input_buffer(), "http");
+
+        view.input_backspace();
+        assert_eq!(view.input_buffer(), "htt");
+
+        view.cancel_input();
+        assert_eq!(view.input_mode(), InputMode::Normal);
+        assert!(view.input_buffer().is_empty());
+    }
+
+    #[test]
+    fn selected_episode_track_returns_none_in_feed_list() {
+        let state = state_with_feeds();
+        let view = PodcastView::new(&state);
+        assert!(view.selected_episode_track().is_none());
+    }
+
+    #[test]
+    fn remove_feed_clamps_selection() {
+        let state = state_with_feeds();
+        let mut view = PodcastView::new(&state);
+
+        // Select last feed
+        view.select_down();
+        view.select_down();
+        assert_eq!(view.selected_feed_index(), 2);
+
+        // Remove last — selection should clamp to new last
+        view.remove_feed(2);
+        assert_eq!(view.feeds().len(), 2);
+        assert_eq!(view.selected_feed_index(), 1);
+    }
+}


### PR DESCRIPTION
## Description

Add OPML import/export and a full podcast subscription management view in the TUI.

### What's included

- **OPML import/export**: `--import-opml <FILE>` reads an OPML file and adds podcast feeds to subscriptions (deduplicates by URL, prints summary). `--export-opml <FILE>` writes all subscriptions to a portable OPML 2.0 file. No XML crate needed — uses robust string-based parsing that handles nested groups, single/double quotes, and malformed input.
- **Podcast TUI view**: Press `P` (Shift+P) to open a podcast management overlay. Browse subscribed feeds with episode counts, drill into a feed to see episodes with played/unplayed indicators, duration, and publish dates. Play any episode with Enter.
- **Feed management**: Press `a` in the podcast view to add a feed by URL (inline text input), `x`/`Delete` to remove a feed, `R` to refresh feeds. State is persisted to `podcasts.toml` after every change.
- **Lazy refresh**: Feeds are refreshed on first open of the podcast view, not on every startup.

## Related Issues

Closes #28, closes #29

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `playback/` — Decode, DSP, state machine
- [x] `providers/` — Audio sources (local, radio, podcast)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (206 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)