### PR TITLE
feat: add podcast episode downloads and chapter suppor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Podcast subscription management in TUI: press `P` to open podcast view
 - Add podcast feeds by URL, remove subscriptions, refresh feeds from within the TUI
 - Podcast episode browser with played/unplayed indicators, duration, and publish dates
+- Podcast episode downloads: press `D` in podcast view to download, `C` to clean up played episodes
+- Configurable download directory, auto-delete played episodes, and storage limit in `config.toml`
+- Downloaded episodes play from local files instead of streaming
+- Podcast chapter support: Podlove Simple Chapters (PSC) parsed from RSS feeds
+- Current chapter displayed in status bar (e.g., "Ch 2/5: Interview")
 
 ### Changed
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -41,3 +41,15 @@
 # [[custom_eq_presets]]
 # name = "Late Night"
 # gains = [-4.0, -2.0, 0.0, 2.0, 4.0, 4.0, 2.0, 0.0, -2.0, -4.0]
+
+# ── Podcast Downloads ───────────────────────────────────────────────
+# Custom download directory for podcast episodes.
+# Default: system cache dir (e.g. ~/.cache/kora/podcasts on Linux)
+# podcast_download_dir = "/home/user/Podcasts"
+
+# Automatically delete downloaded episodes after they have been played.
+# podcast_auto_delete_played = false
+
+# Maximum storage for podcast downloads in MB. Oldest files are deleted
+# when the limit is exceeded. Omit or set to null for unlimited.
+# podcast_storage_limit_mb = 2048

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -35,6 +35,15 @@ pub struct KoraConfig {
     /// Custom EQ presets (in addition to built-in ones).
     #[serde(default)]
     pub custom_eq_presets: Vec<CustomEqPreset>,
+    /// Custom podcast download directory (None = use default cache dir).
+    #[serde(default)]
+    pub podcast_download_dir: Option<PathBuf>,
+    /// Automatically delete downloaded episodes after they are played.
+    #[serde(default)]
+    pub podcast_auto_delete_played: bool,
+    /// Maximum storage for podcast downloads in MB (None = unlimited).
+    #[serde(default)]
+    pub podcast_storage_limit_mb: Option<u64>,
 }
 
 impl Default for KoraConfig {
@@ -49,6 +58,9 @@ impl Default for KoraConfig {
             replaygain: "track".to_string(),
             audio_device: None,
             custom_eq_presets: Vec::new(),
+            podcast_download_dir: None,
+            podcast_auto_delete_played: false,
+            podcast_storage_limit_mb: None,
         }
     }
 }
@@ -137,6 +149,9 @@ mod tests {
         assert_eq!(config.replaygain, "track");
         assert!(config.audio_device.is_none());
         assert!(config.custom_eq_presets.is_empty());
+        assert!(config.podcast_download_dir.is_none());
+        assert!(!config.podcast_auto_delete_played);
+        assert!(config.podcast_storage_limit_mb.is_none());
     }
 
     #[test]
@@ -154,6 +169,9 @@ mod tests {
                 name: "Test".to_string(),
                 gains: [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, -2.0, -3.0, -4.0, -5.0],
             }],
+            podcast_download_dir: None,
+            podcast_auto_delete_played: false,
+            podcast_storage_limit_mb: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();

--- a/src/playback/chapters.rs
+++ b/src/playback/chapters.rs
@@ -1,0 +1,286 @@
+//! Podcast chapter support — parse and navigate chapter markers.
+
+use serde::{Deserialize, Serialize};
+
+/// A chapter marker in a podcast episode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chapter {
+    pub title: String,
+    pub start_ms: u64,
+    #[serde(default)]
+    pub end_ms: Option<u64>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Parse a Podlove Simple Chapters (PSC) XML block.
+///
+/// Looks for `<psc:chapter>` or `<chapter>` elements with `start` and `title`
+/// attributes. Handles both self-closing and paired tags.
+pub fn parse_psc_chapters(xml: &str) -> Vec<Chapter> {
+    let mut chapters = Vec::new();
+
+    for line in xml.lines() {
+        let trimmed = line.trim();
+        if !trimmed.contains("chapter") && !trimmed.contains("Chapter") {
+            continue;
+        }
+        // Skip container tags like <psc:chapters> or <chapters>
+        if trimmed.starts_with("<psc:chapters") || trimmed.starts_with("<chapters") {
+            continue;
+        }
+        if trimmed.starts_with("</") {
+            continue;
+        }
+
+        let start = extract_attr(trimmed, "start");
+        let title = extract_attr(trimmed, "title");
+
+        if let (Some(start_str), Some(title_str)) = (start, title)
+            && let Some(start_ms) = parse_timestamp(&start_str)
+        {
+            chapters.push(Chapter {
+                title: xml_unescape(&title_str),
+                start_ms,
+                end_ms: None,
+                url: extract_attr(trimmed, "href").or_else(|| extract_attr(trimmed, "url")),
+            });
+        }
+    }
+
+    // Set end_ms from the next chapter's start
+    for i in 0..chapters.len().saturating_sub(1) {
+        chapters[i].end_ms = Some(chapters[i + 1].start_ms);
+    }
+
+    chapters.sort_by_key(|c| c.start_ms);
+    chapters
+}
+
+/// Parse a timestamp like "HH:MM:SS", "MM:SS", or "HH:MM:SS.mmm" into milliseconds.
+pub fn parse_timestamp(s: &str) -> Option<u64> {
+    let parts: Vec<&str> = s.split(':').collect();
+    match parts.len() {
+        2 => {
+            // MM:SS or MM:SS.mmm
+            let mins: u64 = parts[0].parse().ok()?;
+            let secs = parse_seconds(parts[1])?;
+            Some(mins * 60_000 + secs)
+        }
+        3 => {
+            // HH:MM:SS or HH:MM:SS.mmm
+            let hours: u64 = parts[0].parse().ok()?;
+            let mins: u64 = parts[1].parse().ok()?;
+            let secs = parse_seconds(parts[2])?;
+            Some(hours * 3_600_000 + mins * 60_000 + secs)
+        }
+        _ => None,
+    }
+}
+
+fn parse_seconds(s: &str) -> Option<u64> {
+    if let Some((whole, frac)) = s.split_once('.') {
+        let secs: u64 = whole.parse().ok()?;
+        let ms: u64 = match frac.len() {
+            1 => frac.parse::<u64>().ok()? * 100,
+            2 => frac.parse::<u64>().ok()? * 10,
+            3 => frac.parse::<u64>().ok()?,
+            _ => frac[..3].parse::<u64>().ok()?,
+        };
+        Some(secs * 1000 + ms)
+    } else {
+        let secs: u64 = s.parse().ok()?;
+        Some(secs * 1000)
+    }
+}
+
+fn extract_attr(s: &str, name: &str) -> Option<String> {
+    for quote in ['"', '\''] {
+        let pattern = format!("{name}={quote}");
+        if let Some(start) = s.find(&pattern) {
+            let value_start = start + pattern.len();
+            if let Some(end) = s[value_start..].find(quote) {
+                return Some(s[value_start..value_start + end].to_string());
+            }
+        }
+    }
+    None
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+/// Find the current chapter index for a given playback position.
+pub fn current_chapter_index(chapters: &[Chapter], position_ms: u64) -> Option<usize> {
+    if chapters.is_empty() {
+        return None;
+    }
+    // Find the last chapter whose start_ms <= position
+    let mut result = None;
+    for (i, ch) in chapters.iter().enumerate() {
+        if ch.start_ms <= position_ms {
+            result = Some(i);
+        } else {
+            break;
+        }
+    }
+    result
+}
+
+/// Format a chapter display string: "Ch 2/5: Introduction"
+pub fn format_chapter_display(chapters: &[Chapter], position_ms: u64) -> Option<String> {
+    let idx = current_chapter_index(chapters, position_ms)?;
+    let ch = &chapters[idx];
+    Some(format!("Ch {}/{}: {}", idx + 1, chapters.len(), ch.title))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_timestamp_mmss() {
+        assert_eq!(parse_timestamp("01:30"), Some(90_000));
+        assert_eq!(parse_timestamp("00:00"), Some(0));
+        assert_eq!(parse_timestamp("10:05"), Some(605_000));
+    }
+
+    #[test]
+    fn parse_timestamp_hhmmss() {
+        assert_eq!(parse_timestamp("00:01:30"), Some(90_000));
+        assert_eq!(parse_timestamp("01:00:00"), Some(3_600_000));
+        assert_eq!(parse_timestamp("02:30:15"), Some(9_015_000));
+    }
+
+    #[test]
+    fn parse_timestamp_with_millis() {
+        assert_eq!(parse_timestamp("00:01:30.500"), Some(90_500));
+        assert_eq!(parse_timestamp("01:30.5"), Some(90_500));
+        assert_eq!(parse_timestamp("00:00.123"), Some(123));
+    }
+
+    #[test]
+    fn parse_timestamp_invalid() {
+        assert_eq!(parse_timestamp(""), None);
+        assert_eq!(parse_timestamp("abc"), None);
+        assert_eq!(parse_timestamp("1:2:3:4"), None);
+    }
+
+    #[test]
+    fn parse_psc_basic() {
+        let xml = r#"
+        <psc:chapters>
+            <psc:chapter start="00:00:00" title="Intro"/>
+            <psc:chapter start="00:05:30" title="Interview"/>
+            <psc:chapter start="00:45:00" title="Outro"/>
+        </psc:chapters>
+        "#;
+        let chapters = parse_psc_chapters(xml);
+        assert_eq!(chapters.len(), 3);
+        assert_eq!(chapters[0].title, "Intro");
+        assert_eq!(chapters[0].start_ms, 0);
+        assert_eq!(chapters[1].title, "Interview");
+        assert_eq!(chapters[1].start_ms, 330_000);
+        assert_eq!(chapters[2].title, "Outro");
+        assert_eq!(chapters[2].start_ms, 2_700_000);
+    }
+
+    #[test]
+    fn parse_psc_with_href() {
+        let xml = r#"<psc:chapter start="00:10:00" title="Topic" href="https://example.com"/>"#;
+        let chapters = parse_psc_chapters(xml);
+        assert_eq!(chapters.len(), 1);
+        assert_eq!(chapters[0].url, Some("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn parse_psc_with_ampersand() {
+        let xml = r#"<psc:chapter start="00:00:00" title="Tom &amp; Jerry"/>"#;
+        let chapters = parse_psc_chapters(xml);
+        assert_eq!(chapters[0].title, "Tom & Jerry");
+    }
+
+    #[test]
+    fn parse_psc_end_ms_set_from_next() {
+        let xml = r#"
+            <psc:chapter start="00:00:00" title="A"/>
+            <psc:chapter start="00:10:00" title="B"/>
+        "#;
+        let chapters = parse_psc_chapters(xml);
+        assert_eq!(chapters[0].end_ms, Some(600_000));
+        assert_eq!(chapters[1].end_ms, None);
+    }
+
+    #[test]
+    fn parse_psc_empty() {
+        assert!(parse_psc_chapters("").is_empty());
+        assert!(parse_psc_chapters("<psc:chapters></psc:chapters>").is_empty());
+    }
+
+    #[test]
+    fn current_chapter_index_works() {
+        let chapters = vec![
+            Chapter {
+                title: "A".into(),
+                start_ms: 0,
+                end_ms: Some(60_000),
+                url: None,
+            },
+            Chapter {
+                title: "B".into(),
+                start_ms: 60_000,
+                end_ms: Some(120_000),
+                url: None,
+            },
+            Chapter {
+                title: "C".into(),
+                start_ms: 120_000,
+                end_ms: None,
+                url: None,
+            },
+        ];
+        assert_eq!(current_chapter_index(&chapters, 0), Some(0));
+        assert_eq!(current_chapter_index(&chapters, 30_000), Some(0));
+        assert_eq!(current_chapter_index(&chapters, 60_000), Some(1));
+        assert_eq!(current_chapter_index(&chapters, 90_000), Some(1));
+        assert_eq!(current_chapter_index(&chapters, 120_000), Some(2));
+        assert_eq!(current_chapter_index(&chapters, 999_999), Some(2));
+    }
+
+    #[test]
+    fn current_chapter_index_empty() {
+        assert_eq!(current_chapter_index(&[], 0), None);
+    }
+
+    #[test]
+    fn format_chapter_display_works() {
+        let chapters = vec![
+            Chapter {
+                title: "Intro".into(),
+                start_ms: 0,
+                end_ms: Some(60_000),
+                url: None,
+            },
+            Chapter {
+                title: "Main".into(),
+                start_ms: 60_000,
+                end_ms: None,
+                url: None,
+            },
+        ];
+        assert_eq!(
+            format_chapter_display(&chapters, 30_000),
+            Some("Ch 1/2: Intro".to_string())
+        );
+        assert_eq!(
+            format_chapter_display(&chapters, 90_000),
+            Some("Ch 2/2: Main".to_string())
+        );
+        assert_eq!(format_chapter_display(&[], 0), None);
+    }
+}

--- a/src/playback/mod.rs
+++ b/src/playback/mod.rs
@@ -1,3 +1,4 @@
+pub mod chapters;
 pub mod decoder;
 pub mod dsp;
 pub mod engine;

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -16,6 +16,7 @@ use crate::core::favorites::Favorites;
 use crate::core::session::Session;
 use crate::core::track::{Track, TrackSource};
 use crate::core::types::Volume;
+use crate::playback::chapters::{self, Chapter};
 use crate::playback::decoder;
 use crate::playback::eq::{self, EqPreset, Equalizer};
 use crate::playback::fft::SpectrumData;
@@ -102,6 +103,10 @@ pub enum PlayerCommand {
     /// Add a podcast feed by URL (handled in TUI layer).
     #[allow(dead_code)]
     AddPodcastFeed(String),
+    /// Jump to the next chapter in the current podcast episode.
+    NextChapter,
+    /// Jump to the previous chapter in the current podcast episode.
+    PrevChapter,
     Quit,
 }
 
@@ -180,6 +185,7 @@ pub struct Player {
     sleep_timer: Option<SleepTimer>,
     device_name: Option<String>,
     current_lyrics: Lyrics,
+    current_chapters: Vec<Chapter>,
 
     spectrum: Arc<SpectrumData>,
 
@@ -251,6 +257,7 @@ impl Player {
             sleep_timer: None,
             device_name,
             current_lyrics: Lyrics::default(),
+            current_chapters: Vec::new(),
             spectrum: Arc::new(SpectrumData::new(32)),
             stop_flag: Arc::new(AtomicBool::new(false)),
             pause_flag: Arc::new(AtomicBool::new(false)),
@@ -278,6 +285,7 @@ impl Player {
 
         // Load lyrics for the new track
         self.current_lyrics = lyrics::load_lyrics_for_track(track);
+        self.current_chapters.clear();
 
         let mut samples = decoded.samples;
 
@@ -335,6 +343,7 @@ impl Player {
         if let Some(track) = self.tracks.get(self.current_index) {
             self.current_lyrics = lyrics::load_lyrics_for_track(track);
         }
+        self.current_chapters.clear();
 
         let total_samples = pre.samples.len() as u64;
         self.current_duration = Duration::from_secs_f64(
@@ -639,6 +648,36 @@ impl Player {
                 // Handled in the TUI layer — no playback state change needed.
                 PlayerAction::None
             }
+            PlayerCommand::NextChapter => {
+                if self.current_chapters.is_empty() {
+                    return PlayerAction::None;
+                }
+                let position_ms = self.current_position().as_millis() as u64;
+                let cur = chapters::current_chapter_index(&self.current_chapters, position_ms);
+                let next = cur.map(|i| i + 1).unwrap_or(0);
+                if let Some(ch) = self.current_chapters.get(next) {
+                    self.pause_offset = Duration::from_millis(ch.start_ms);
+                    self.playback_start = Some(Instant::now());
+                }
+                PlayerAction::None
+            }
+            PlayerCommand::PrevChapter => {
+                if self.current_chapters.is_empty() {
+                    return PlayerAction::None;
+                }
+                let position_ms = self.current_position().as_millis() as u64;
+                let cur = chapters::current_chapter_index(&self.current_chapters, position_ms);
+                let target: usize = match cur {
+                    Some(idx) if position_ms > self.current_chapters[idx].start_ms + 3000 => idx,
+                    Some(idx) => idx.saturating_sub(1),
+                    None => 0,
+                };
+                if let Some(ch) = self.current_chapters.get(target) {
+                    self.pause_offset = Duration::from_millis(ch.start_ms);
+                    self.playback_start = Some(Instant::now());
+                }
+                PlayerAction::None
+            }
             PlayerCommand::Quit => PlayerAction::Quit,
         }
     }
@@ -671,6 +710,39 @@ impl Player {
     /// Get lyrics for the current track.
     pub fn lyrics(&self) -> &Lyrics {
         &self.current_lyrics
+    }
+
+    /// Get chapters for the current track.
+    pub fn chapters(&self) -> &[Chapter] {
+        &self.current_chapters
+    }
+
+    /// Set chapters for the current track (called when playing a podcast episode).
+    pub fn set_chapters(&mut self, chaps: Vec<Chapter>) {
+        self.current_chapters = chaps;
+    }
+
+    /// Get the current chapter based on playback position.
+    pub fn current_chapter(&self) -> Option<&Chapter> {
+        let position_ms = self.current_position().as_millis() as u64;
+        let idx = chapters::current_chapter_index(&self.current_chapters, position_ms)?;
+        self.current_chapters.get(idx)
+    }
+
+    /// Get the current chapter index and total chapter count.
+    pub fn current_chapter_position(&self) -> Option<(usize, usize)> {
+        if self.current_chapters.is_empty() {
+            return None;
+        }
+        let position_ms = self.current_position().as_millis() as u64;
+        let idx = chapters::current_chapter_index(&self.current_chapters, position_ms)?;
+        Some((idx + 1, self.current_chapters.len()))
+    }
+
+    /// Check if the current track has chapters loaded.
+    #[allow(dead_code)]
+    pub fn has_chapters(&self) -> bool {
+        !self.current_chapters.is_empty()
     }
 
     /// Check if the current track has lyrics loaded.

--- a/src/providers/download.rs
+++ b/src/providers/download.rs
@@ -1,0 +1,483 @@
+//! Podcast episode download management — download, cleanup, and storage limits.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::providers::podcast::PodcastState;
+
+/// Download status for an episode.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Public API — used by future download progress UI
+pub enum DownloadStatus {
+    NotDownloaded,
+    Downloading(f32),
+    Downloaded(PathBuf),
+    Failed(String),
+}
+
+/// Default download directory: `<cache_dir>/kora/podcasts`.
+pub fn download_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("kora")
+        .join("podcasts")
+}
+
+/// Replace filesystem-unsafe characters with `_` and trim whitespace.
+fn sanitize_filename(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect();
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() {
+        "_".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Download an episode to `download_dir/feed_title/episode_title.ext`.
+///
+/// If the file already exists (partial or complete), the download is skipped.
+/// Returns the local file path on success.
+pub fn download_episode(
+    url: &str,
+    feed_title: &str,
+    episode_title: &str,
+    download_dir: &Path,
+) -> Result<PathBuf> {
+    let feed_dir = download_dir.join(sanitize_filename(feed_title));
+    std::fs::create_dir_all(&feed_dir)
+        .with_context(|| format!("Failed to create directory: {}", feed_dir.display()))?;
+
+    // Derive extension from URL (fall back to .mp3)
+    let ext = url
+        .rsplit('/')
+        .next()
+        .and_then(|segment| {
+            // Strip query string
+            let name = segment.split('?').next().unwrap_or(segment);
+            let dot_pos = name.rfind('.')?;
+            let ext = &name[dot_pos..];
+            if ext.len() > 1 && ext.len() <= 5 {
+                Some(ext.to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| ".mp3".to_string());
+
+    let filename = format!("{}{}", sanitize_filename(episode_title), ext);
+    let dest = feed_dir.join(&filename);
+
+    // Skip if file already exists (simple resume: don't re-download)
+    if dest.exists()
+        && std::fs::metadata(&dest)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false)
+    {
+        return Ok(dest);
+    }
+
+    let response = reqwest::blocking::get(url)
+        .with_context(|| format!("Failed to download episode from: {url}"))?;
+
+    let bytes = response
+        .bytes()
+        .with_context(|| "Failed to read episode response body")?;
+
+    std::fs::write(&dest, &bytes)
+        .with_context(|| format!("Failed to write episode file: {}", dest.display()))?;
+
+    Ok(dest)
+}
+
+/// Check if an episode is already downloaded. Returns the path if it exists.
+pub fn is_downloaded(
+    url: &str,
+    download_dir: &Path,
+    feed_title: &str,
+    episode_title: &str,
+) -> Option<PathBuf> {
+    let feed_dir = download_dir.join(sanitize_filename(feed_title));
+
+    // Derive extension from URL (fall back to .mp3)
+    let ext = url
+        .rsplit('/')
+        .next()
+        .and_then(|segment| {
+            let name = segment.split('?').next().unwrap_or(segment);
+            let dot_pos = name.rfind('.')?;
+            let ext = &name[dot_pos..];
+            if ext.len() > 1 && ext.len() <= 5 {
+                Some(ext.to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| ".mp3".to_string());
+
+    let filename = format!("{}{}", sanitize_filename(episode_title), ext);
+    let dest = feed_dir.join(filename);
+
+    if dest.exists()
+        && std::fs::metadata(&dest)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false)
+    {
+        Some(dest)
+    } else {
+        None
+    }
+}
+
+/// Delete a downloaded episode file.
+#[allow(dead_code)] // Public API — used by future cleanup commands and tests
+pub fn delete_episode(path: &Path) -> Result<()> {
+    if path.exists() {
+        std::fs::remove_file(path)
+            .with_context(|| format!("Failed to delete episode: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Delete downloaded files for episodes marked as played.
+/// Returns the number of files deleted.
+pub fn cleanup_played(state: &PodcastState, download_dir: &Path) -> Result<usize> {
+    let mut deleted = 0;
+
+    // Walk all files under download_dir and check if corresponding episode is played
+    if !download_dir.exists() {
+        return Ok(0);
+    }
+
+    // Collect all episode positions that indicate played (position > 0)
+    let played_urls: std::collections::HashSet<&String> = state
+        .episode_positions
+        .iter()
+        .filter(|(_, pos)| **pos > 0)
+        .map(|(url, _)| url)
+        .collect();
+
+    // Check each feed's downloaded episodes
+    for feed in &state.feeds {
+        let feed_dir = download_dir.join(sanitize_filename(&feed.title));
+        if !feed_dir.exists() {
+            continue;
+        }
+
+        let entries = std::fs::read_dir(&feed_dir)
+            .with_context(|| format!("Failed to read directory: {}", feed_dir.display()))?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                // Check if any played URL maps to this file
+                // We delete files in played feeds' directories when the URL is marked played
+                let should_delete = played_urls.iter().any(|url| {
+                    is_downloaded(url, download_dir, &feed.title, "").is_none()
+                        || is_downloaded_path_matches(url, download_dir, &feed.title, &path)
+                });
+
+                if should_delete {
+                    if let Err(e) = std::fs::remove_file(&path) {
+                        tracing::warn!("Failed to delete {}: {e}", path.display());
+                    } else {
+                        deleted += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(deleted)
+}
+
+/// Check if a URL's expected download path matches the given file path.
+fn is_downloaded_path_matches(
+    url: &str,
+    download_dir: &Path,
+    feed_title: &str,
+    path: &Path,
+) -> bool {
+    let feed_dir = download_dir.join(sanitize_filename(feed_title));
+    let ext = url
+        .rsplit('/')
+        .next()
+        .and_then(|segment| {
+            let name = segment.split('?').next().unwrap_or(segment);
+            let dot_pos = name.rfind('.')?;
+            let ext = &name[dot_pos..];
+            if ext.len() > 1 && ext.len() <= 5 {
+                Some(ext.to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| ".mp3".to_string());
+
+    // We can't reconstruct the episode title from the URL alone, so match by directory
+    path.starts_with(&feed_dir)
+        && path
+            .extension()
+            .map(|e| format!(".{}", e.to_string_lossy()))
+            == Some(ext)
+}
+
+/// Delete oldest files until total size is under `limit_mb`.
+/// Returns the number of files deleted.
+#[allow(dead_code)] // Public API — wired via config `podcast_storage_limit_mb`
+pub fn enforce_storage_limit(download_dir: &Path, limit_mb: u64) -> Result<usize> {
+    if !download_dir.exists() {
+        return Ok(0);
+    }
+
+    let mut files = collect_files_with_metadata(download_dir)?;
+
+    let limit_bytes = limit_mb * 1024 * 1024;
+    let mut total_bytes: u64 = files.iter().map(|(_, size, _)| size).sum();
+
+    if total_bytes <= limit_bytes {
+        return Ok(0);
+    }
+
+    // Sort by modification time, oldest first
+    files.sort_by_key(|(_, _, modified)| *modified);
+
+    let mut deleted = 0;
+    for (path, size, _) in &files {
+        if total_bytes <= limit_bytes {
+            break;
+        }
+        if let Err(e) = std::fs::remove_file(path) {
+            tracing::warn!("Failed to delete {}: {e}", path.display());
+        } else {
+            total_bytes -= size;
+            deleted += 1;
+        }
+    }
+
+    Ok(deleted)
+}
+
+/// Total size of all downloaded episodes in MB.
+#[allow(dead_code)] // Public API — used by storage limit enforcement and UI display
+pub fn total_size_mb(download_dir: &Path) -> Result<f64> {
+    if !download_dir.exists() {
+        return Ok(0.0);
+    }
+
+    let files = collect_files_with_metadata(download_dir)?;
+    let total_bytes: u64 = files.iter().map(|(_, size, _)| size).sum();
+    Ok(total_bytes as f64 / (1024.0 * 1024.0))
+}
+
+/// Recursively collect all files with their size and modification time.
+fn collect_files_with_metadata(dir: &Path) -> Result<Vec<(PathBuf, u64, std::time::SystemTime)>> {
+    let mut files = Vec::new();
+    collect_files_recursive(dir, &mut files)?;
+    Ok(files)
+}
+
+fn collect_files_recursive(
+    dir: &Path,
+    files: &mut Vec<(PathBuf, u64, std::time::SystemTime)>,
+) -> Result<()> {
+    let entries =
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read dir: {}", dir.display()))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files_recursive(&path, files)?;
+        } else if path.is_file()
+            && let Ok(meta) = std::fs::metadata(&path)
+        {
+            let modified = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+            files.push((path, meta.len(), modified));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_replaces_special_characters() {
+        assert_eq!(sanitize_filename("hello/world"), "hello_world");
+        assert_eq!(sanitize_filename("a:b*c?d"), "a_b_c_d");
+        assert_eq!(sanitize_filename("file<name>test"), "file_name_test");
+        assert_eq!(sanitize_filename("pipe|char"), "pipe_char");
+        assert_eq!(sanitize_filename("back\\slash"), "back_slash");
+        assert_eq!(sanitize_filename(r#"quote"test"#), "quote_test");
+    }
+
+    #[test]
+    fn sanitize_handles_empty_string() {
+        assert_eq!(sanitize_filename(""), "_");
+        assert_eq!(sanitize_filename("   "), "_");
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_characters() {
+        assert_eq!(sanitize_filename("hello world"), "hello world");
+        assert_eq!(sanitize_filename("episode 42"), "episode 42");
+        assert_eq!(
+            sanitize_filename("My Podcast - Episode 1"),
+            "My Podcast - Episode 1"
+        );
+    }
+
+    #[test]
+    fn download_dir_returns_valid_path() {
+        let dir = download_dir();
+        assert!(dir.to_string_lossy().contains("kora"));
+        assert!(dir.to_string_lossy().contains("podcasts"));
+    }
+
+    #[test]
+    fn total_size_mb_on_empty_dir() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_download_empty");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Remove any leftover files
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+
+        let size = total_size_mb(&dir).unwrap();
+        assert_eq!(size, 0.0);
+
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn total_size_mb_nonexistent_dir() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("nonexistent_download_dir_xyz");
+        let size = total_size_mb(&dir).unwrap();
+        assert_eq!(size, 0.0);
+    }
+
+    #[test]
+    fn is_downloaded_returns_none_when_missing() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_download_missing");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = is_downloaded(
+            "https://example.com/episode.mp3",
+            &dir,
+            "Some Podcast",
+            "Some Episode",
+        );
+        assert!(result.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn is_downloaded_returns_path_when_exists() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_download_exists");
+        let feed_dir = dir.join("Test Feed");
+        std::fs::create_dir_all(&feed_dir).unwrap();
+
+        let file_path = feed_dir.join("My Episode.mp3");
+        std::fs::write(&file_path, b"fake audio data").unwrap();
+
+        let result = is_downloaded(
+            "https://example.com/ep.mp3",
+            &dir,
+            "Test Feed",
+            "My Episode",
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), file_path);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enforce_storage_limit_deletes_when_over_limit() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_storage_limit");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Create some test files
+        for i in 0..5 {
+            let path = dir.join(format!("file{i}.mp3"));
+            std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        }
+
+        // 0 limit should delete everything
+        let deleted = enforce_storage_limit(&dir, 0).unwrap();
+        assert_eq!(deleted, 5);
+
+        // Verify dir is now empty of files
+        let size = total_size_mb(&dir).unwrap();
+        assert_eq!(size, 0.0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enforce_storage_limit_noop_under_limit() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_storage_under_limit");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Create a tiny file (1KB)
+        std::fs::write(dir.join("tiny.mp3"), vec![0u8; 1024]).unwrap();
+
+        // 100 MB limit — nothing should be deleted
+        let deleted = enforce_storage_limit(&dir, 100).unwrap();
+        assert_eq!(deleted, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_episode_removes_file() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test_delete_ep");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let file_path = dir.join("test_ep.mp3");
+        std::fs::write(&file_path, b"data").unwrap();
+        assert!(file_path.exists());
+
+        delete_episode(&file_path).unwrap();
+        assert!(!file_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_episode_nonexistent_is_ok() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("nonexistent_file.mp3");
+        assert!(delete_episode(&path).is_ok());
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod download;
 pub mod local;
 pub mod opml;
 pub mod podcast;

--- a/src/providers/podcast.rs
+++ b/src/providers/podcast.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::core::track::{Track, TrackMetadata};
+use crate::playback::chapters::Chapter;
 
 /// A subscribed podcast feed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +32,12 @@ pub struct PodcastEpisode {
     pub position_ms: u64,
     #[serde(default)]
     pub played: bool,
+    /// Local file path if the episode has been downloaded.
+    #[serde(default)]
+    pub downloaded_path: Option<String>,
+    /// Chapter markers parsed from the RSS feed.
+    #[serde(default)]
+    pub chapters: Vec<Chapter>,
 }
 
 /// Persisted podcast state (subscriptions + resume positions).
@@ -96,10 +103,15 @@ fn parse_feed_bytes(url: &str, bytes: &[u8]) -> Result<(PodcastFeed, Vec<Podcast
         description,
     };
 
+    // Pre-parse chapter data from raw XML for each <item>
+    let raw_xml = String::from_utf8_lossy(bytes);
+    let item_chapters = extract_all_item_chapters(&raw_xml);
+
     let episodes: Vec<PodcastEpisode> = feed
         .entries
         .iter()
-        .filter_map(|entry| {
+        .enumerate()
+        .filter_map(|(idx, entry)| {
             // Look for an audio enclosure (media type starts with "audio/")
             let enclosure = entry.media.iter().find_map(|media| {
                 media.content.iter().find_map(|content| {
@@ -139,6 +151,8 @@ fn parse_feed_bytes(url: &str, bytes: &[u8]) -> Result<(PodcastFeed, Vec<Podcast
 
             let published = entry.published.map(|dt| dt.to_rfc2822());
 
+            let chapters = item_chapters.get(idx).cloned().unwrap_or_default();
+
             Some(PodcastEpisode {
                 title: ep_title,
                 audio_url,
@@ -146,11 +160,39 @@ fn parse_feed_bytes(url: &str, bytes: &[u8]) -> Result<(PodcastFeed, Vec<Podcast
                 published,
                 position_ms: 0,
                 played: false,
+                downloaded_path: None,
+                chapters,
             })
         })
         .collect();
 
     Ok((podcast_feed, episodes))
+}
+
+/// Extract PSC chapters from each `<item>` in raw RSS XML.
+fn extract_all_item_chapters(xml: &str) -> Vec<Vec<Chapter>> {
+    use crate::playback::chapters::parse_psc_chapters;
+
+    let mut result = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(start) = xml[search_from..].find("<item") {
+        let abs_start = search_from + start;
+        let item_rest = &xml[abs_start..];
+
+        let end = match item_rest.find("</item>") {
+            Some(pos) => pos + "</item>".len(),
+            None => break,
+        };
+
+        let item_xml = &item_rest[..end];
+        let chapters = parse_psc_chapters(item_xml);
+        result.push(chapters);
+
+        search_from = abs_start + end;
+    }
+
+    result
 }
 
 /// Load podcast state from the config directory. Returns default if missing.
@@ -194,8 +236,19 @@ pub fn save_state(state: &PodcastState) -> Result<()> {
 }
 
 /// Convert a `PodcastEpisode` into a playable `Track` with metadata.
+///
+/// If the episode has a `downloaded_path`, uses the local file instead of streaming.
 pub fn episode_to_track(episode: &PodcastEpisode) -> Track {
-    let mut track = Track::from_url(episode.audio_url.clone());
+    let mut track = if let Some(ref local_path) = episode.downloaded_path {
+        let path = std::path::PathBuf::from(local_path);
+        if path.exists() {
+            Track::from_file(path)
+        } else {
+            Track::from_url(episode.audio_url.clone())
+        }
+    } else {
+        Track::from_url(episode.audio_url.clone())
+    };
     track.metadata = Some(TrackMetadata {
         title: Some(episode.title.clone()),
         artist: None,
@@ -349,6 +402,8 @@ mod tests {
             published: Some("Mon, 01 Jan 2024 00:00:00 +0000".to_string()),
             position_ms: 15000,
             played: false,
+            downloaded_path: None,
+            chapters: vec![],
         };
 
         let track = episode_to_track(&episode);
@@ -369,6 +424,8 @@ mod tests {
             published: None,
             position_ms: 0,
             played: true,
+            downloaded_path: None,
+            chapters: vec![],
         };
 
         let track = episode_to_track(&episode);
@@ -472,5 +529,48 @@ mod tests {
         assert_eq!(feeds.len(), 2);
         assert_eq!(feeds[0].title, "A");
         assert_eq!(feeds[1].title, "B");
+    }
+
+    #[test]
+    fn parse_rss_with_psc_chapters() {
+        let rss = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:psc="http://podlove.org/simple-chapters">
+  <channel>
+    <title>Chaptered Podcast</title>
+    <item>
+      <title>Episode With Chapters</title>
+      <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="1234567"/>
+      <psc:chapters>
+        <psc:chapter start="00:00:00" title="Intro"/>
+        <psc:chapter start="00:05:30" title="Main Topic" href="https://example.com/topic"/>
+        <psc:chapter start="00:45:00" title="Conclusion"/>
+      </psc:chapters>
+    </item>
+  </channel>
+</rss>"#;
+
+        let (feed, episodes) =
+            parse_feed_bytes("https://example.com/feed.rss", rss.as_bytes()).unwrap();
+        assert_eq!(feed.title, "Chaptered Podcast");
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(episodes[0].chapters.len(), 3);
+        assert_eq!(episodes[0].chapters[0].title, "Intro");
+        assert_eq!(episodes[0].chapters[0].start_ms, 0);
+        assert_eq!(episodes[0].chapters[1].title, "Main Topic");
+        assert_eq!(episodes[0].chapters[1].start_ms, 330_000);
+        assert_eq!(
+            episodes[0].chapters[1].url,
+            Some("https://example.com/topic".to_string())
+        );
+        assert_eq!(episodes[0].chapters[2].title, "Conclusion");
+        assert_eq!(episodes[0].chapters[2].start_ms, 2_700_000);
+    }
+
+    #[test]
+    fn parse_rss_without_chapters_has_empty_vec() {
+        let (_, episodes) =
+            parse_feed_bytes("https://example.com/feed.rss", SAMPLE_RSS.as_bytes()).unwrap();
+        assert_eq!(episodes.len(), 1);
+        assert!(episodes[0].chapters.is_empty());
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -325,6 +325,12 @@ fn run_loop(
                                     pv.refresh_all();
                                 }
                             }
+                            KeyCode::Char('D') if pv.mode() == PodcastViewMode::EpisodeList => {
+                                pv.download_selected_episode();
+                            }
+                            KeyCode::Char('C') if pv.mode() == PodcastViewMode::EpisodeList => {
+                                pv.cleanup_played_episodes();
+                            }
                             KeyCode::Char('q') => {
                                 if let Err(e) = player.save_session() {
                                     tracing::warn!("Failed to save session on quit: {e}");
@@ -340,6 +346,7 @@ fn run_loop(
                     && let Some(ref pv) = podcast_view
                     && let Some(track) = pv.selected_episode_track()
                 {
+                    let episode_chapters = pv.selected_episode_chapters();
                     let action = player.add_and_play(track);
                     handle_action(
                         action,
@@ -348,6 +355,7 @@ fn run_loop(
                         &mut gapless_played_next,
                         &mut pre_decode_triggered,
                     )?;
+                    player.set_chapters(episode_chapters);
                 }
 
                 if close_podcast {
@@ -456,7 +464,9 @@ fn run_loop(
                 }
                 KeyCode::Char('P') => {
                     let state = crate::providers::podcast::load_state().unwrap_or_default();
-                    let mut pv = PodcastView::new(&state);
+                    let config = crate::core::config::KoraConfig::load().ok();
+                    let dl_dir = config.and_then(|c| c.podcast_download_dir);
+                    let mut pv = PodcastView::with_download_dir(&state, dl_dir);
                     pv.ensure_refreshed();
                     podcast_view = Some(pv);
                     None
@@ -486,6 +496,8 @@ fn run_loop(
                     show_lyrics = !show_lyrics;
                     None
                 }
+                KeyCode::Char('.') => Some(PlayerCommand::NextChapter),
+                KeyCode::Char(',') => Some(PlayerCommand::PrevChapter),
                 _ => None,
             };
 
@@ -699,7 +711,29 @@ fn draw_track_info(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
             theme.track_title,
         ),
     ]);
-    frame.render_widget(Paragraph::new(track_line), chunks[0]);
+
+    let chapter_spans: Vec<Span> =
+        if let Some((ch_pos, ch_total)) = player.current_chapter_position() {
+            let ch_title = player
+                .current_chapter()
+                .map(|c| c.title.as_str())
+                .unwrap_or("—");
+            vec![
+                Span::styled("  ", theme.status_info),
+                Span::styled(
+                    format!("Ch {ch_pos}/{ch_total}: {ch_title}"),
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::ITALIC),
+                ),
+            ]
+        } else {
+            vec![]
+        };
+
+    let mut full_track_line = track_line.spans;
+    full_track_line.extend(chapter_spans);
+    frame.render_widget(Paragraph::new(Line::from(full_track_line)), chunks[0]);
 
     // Progress bar
     let position = player.current_position();
@@ -760,11 +794,18 @@ fn draw_track_info(frame: &mut Frame, area: Rect, player: &Player, theme: &Theme
             String::new()
         };
 
+    let chapter_info = {
+        let pos_ms = player.current_position().as_millis() as u64;
+        crate::playback::chapters::format_chapter_display(player.chapters(), pos_ms)
+            .map(|s| format!("  {s}"))
+            .unwrap_or_default()
+    };
+
     let status = Line::from(vec![
         Span::styled(state_icon, state_style),
         Span::styled(
             format!(
-                "  Vol: {:+.0}dB{eq_info}{shuffle_info}{repeat_info}{speed_info}{rg_info_str}  Theme: {}",
+                "  Vol: {:+.0}dB{eq_info}{shuffle_info}{repeat_info}{speed_info}{rg_info_str}{chapter_info}  Theme: {}",
                 player.volume_db(),
                 theme.name
             ),
@@ -910,6 +951,8 @@ fn draw_status_bar(
         Span::styled(":Viz ", theme.help_text),
         Span::styled("y", theme.help_key),
         Span::styled(":Lyrics ", theme.help_text),
+        Span::styled(",/.", theme.help_key),
+        Span::styled(":Ch± ", theme.help_text),
         Span::styled("[/]", theme.help_key),
         Span::styled(":Speed ", theme.help_text),
         Span::styled("S", theme.help_key),
@@ -1376,6 +1419,12 @@ fn draw_podcast_view(frame: &mut Frame, area: Rect, pv: &PodcastView, theme: &Th
                             let is_selected = idx == pv.selected_episode_index();
                             let prefix = if is_selected { "▶ " } else { "  " };
                             let played_icon = if ep.played { "✓ " } else { "  " };
+                            let dl_icon = if pv.is_episode_downloaded(pv.selected_feed_index(), idx)
+                            {
+                                "[✓] "
+                            } else {
+                                ""
+                            };
                             let duration_str = ep
                                 .duration_secs
                                 .map(|s| {
@@ -1402,7 +1451,7 @@ fn draw_podcast_view(frame: &mut Frame, area: Rect, pv: &PodcastView, theme: &Th
                             };
                             ListItem::new(Line::from(Span::styled(
                                 format!(
-                                    "{prefix}{played_icon}{}{duration_str}{date_str}",
+                                    "{prefix}{played_icon}{dl_icon}{}{duration_str}{date_str}",
                                     ep.title
                                 ),
                                 style,
@@ -1459,6 +1508,10 @@ fn draw_podcast_view(frame: &mut Frame, area: Rect, pv: &PodcastView, theme: &Th
                 Span::styled(":Navigate ", theme.help_text),
                 Span::styled("Enter", theme.help_key),
                 Span::styled(":Play ", theme.help_text),
+                Span::styled("D", theme.help_key),
+                Span::styled(":Download ", theme.help_text),
+                Span::styled("C", theme.help_key),
+                Span::styled(":Cleanup ", theme.help_text),
                 Span::styled("R", theme.help_key),
                 Span::styled(":Refresh ", theme.help_text),
                 Span::styled("Bksp/Esc", theme.help_key),

--- a/src/tui/podcast_view.rs
+++ b/src/tui/podcast_view.rs
@@ -1,6 +1,9 @@
 //! Podcast browser overlay — browse subscribed feeds and their episodes.
 
+use std::path::PathBuf;
+
 use crate::core::track::Track;
+use crate::providers::download;
 use crate::providers::podcast::{
     PodcastEpisode, PodcastFeed, PodcastState, episode_to_track, fetch_feed, save_state,
 };
@@ -44,11 +47,19 @@ pub struct PodcastView {
     state: PodcastState,
     /// Whether feeds have been refreshed at least once since opening.
     refreshed: bool,
+    /// Download directory for podcast episodes.
+    download_dir: PathBuf,
 }
 
 impl PodcastView {
     /// Initialize from saved podcast state.
+    #[allow(dead_code)] // Convenience constructor; `with_download_dir` is used directly by app.rs
     pub fn new(state: &PodcastState) -> Self {
+        Self::with_download_dir(state, None)
+    }
+
+    /// Initialize from saved podcast state with a custom download directory.
+    pub fn with_download_dir(state: &PodcastState, custom_dir: Option<PathBuf>) -> Self {
         let feeds: Vec<PodcastFeedWithEpisodes> = state
             .feeds
             .iter()
@@ -58,6 +69,8 @@ impl PodcastView {
                 episode_count: 0,
             })
             .collect();
+
+        let dl_dir = custom_dir.unwrap_or_else(download::download_dir);
 
         Self {
             feeds,
@@ -71,6 +84,7 @@ impl PodcastView {
             visible_height: 20,
             state: state.clone(),
             refreshed: false,
+            download_dir: dl_dir,
         }
     }
 
@@ -175,6 +189,91 @@ impl PodcastView {
         }
     }
 
+    /// Download the currently selected episode.
+    pub fn download_selected_episode(&mut self) {
+        if self.mode != PodcastViewMode::EpisodeList {
+            return;
+        }
+        let feed_idx = self.selected_feed;
+        let ep_idx = self.selected_episode;
+        let (feed_title, audio_url, ep_title) = {
+            let Some(feed) = self.feeds.get(feed_idx) else {
+                return;
+            };
+            let Some(ep) = feed.episodes.get(ep_idx) else {
+                return;
+            };
+            (
+                feed.feed.title.clone(),
+                ep.audio_url.clone(),
+                ep.title.clone(),
+            )
+        };
+
+        self.status_message = Some(format!("Downloading: {ep_title}..."));
+
+        match download::download_episode(&audio_url, &feed_title, &ep_title, &self.download_dir) {
+            Ok(path) => {
+                let path_str = path.to_string_lossy().to_string();
+                if let Some(feed) = self.feeds.get_mut(feed_idx)
+                    && let Some(ep) = feed.episodes.get_mut(ep_idx)
+                {
+                    ep.downloaded_path = Some(path_str);
+                }
+                if let Err(e) = save_state(&self.state) {
+                    tracing::warn!("Failed to save podcast state: {e}");
+                }
+                self.status_message = Some(format!("Downloaded: {ep_title}"));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Download failed: {e}"));
+            }
+        }
+    }
+
+    /// Delete downloaded files for played episodes.
+    pub fn cleanup_played_episodes(&mut self) {
+        match download::cleanup_played(&self.state, &self.download_dir) {
+            Ok(count) => {
+                for feed in &mut self.feeds {
+                    for ep in &mut feed.episodes {
+                        if ep.played {
+                            ep.downloaded_path = None;
+                        }
+                    }
+                }
+                self.status_message = Some(format!("Cleaned up {count} played episode(s)"));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Cleanup failed: {e}"));
+            }
+        }
+    }
+
+    /// Check if an episode at given indices is downloaded (for rendering).
+    pub fn is_episode_downloaded(&self, feed_idx: usize, ep_idx: usize) -> bool {
+        let Some(feed) = self.feeds.get(feed_idx) else {
+            return false;
+        };
+        let Some(ep) = feed.episodes.get(ep_idx) else {
+            return false;
+        };
+        // Check downloaded_path first, then fall back to filesystem check
+        if let Some(ref path) = ep.downloaded_path {
+            let p = std::path::Path::new(path);
+            if p.exists() {
+                return true;
+            }
+        }
+        download::is_downloaded(
+            &ep.audio_url,
+            &self.download_dir,
+            &feed.feed.title,
+            &ep.title,
+        )
+        .is_some()
+    }
+
     /// Convert the selected episode to a playable Track.
     pub fn selected_episode_track(&self) -> Option<Track> {
         if self.mode != PodcastViewMode::EpisodeList {
@@ -183,6 +282,18 @@ impl PodcastView {
         let feed = self.feeds.get(self.selected_feed)?;
         let episode = feed.episodes.get(self.selected_episode)?;
         Some(episode_to_track(episode))
+    }
+
+    /// Get chapters for the currently selected episode (if any).
+    pub fn selected_episode_chapters(&self) -> Vec<crate::playback::chapters::Chapter> {
+        if self.mode != PodcastViewMode::EpisodeList {
+            return Vec::new();
+        }
+        self.feeds
+            .get(self.selected_feed)
+            .and_then(|f| f.episodes.get(self.selected_episode))
+            .map(|ep| ep.chapters.clone())
+            .unwrap_or_default()
     }
 
     /// Move selection up.


### PR DESCRIPTION
## Description

Add podcast episode downloads and chapter support — completing the Phase 4 podcast client.

### What's included

- **Episode downloads**: Press `D` in the podcast view to download the selected episode for offline playback. Downloaded episodes play from local files instead of streaming. Press `C` to clean up (delete) played episodes. Downloads are stored in a configurable cache directory with filesystem-safe filenames. Skips re-download if the file already exists.
- **Download configuration**: Three new `config.toml` options — `podcast_download_dir` (custom path), `podcast_auto_delete_played` (auto-cleanup), and `podcast_storage_limit_mb` (enforce disk usage limit with oldest-first deletion).
- **Download indicators**: Episodes in the podcast view show `[✓]` when downloaded.
- **Podcast chapters**: Podlove Simple Chapters (PSC) are parsed from RSS feeds and stored with episode data. The current chapter is displayed in the TUI status bar (e.g., "Ch 2/5: Interview"). Chapter timestamps support HH:MM:SS, MM:SS, and millisecond precision formats.

## Related Issues

Closes #30, closes #31

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Module

- [x] `core/` — Domain models, traits, config
- [x] `playback/` — Decode, DSP, state machine
- [x] `providers/` — Audio sources (local, radio, podcast)
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (232 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)