### PR TITLE
feat: add IPC remote control and MPRIS media key integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ALSA (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libdbus-1-dev
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install ALSA
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libdbus-1-dev
 
       - name: Build release
         run: cargo build --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Downloaded episodes play from local files instead of streaming
 - Podcast chapter support: Podlove Simple Chapters (PSC) parsed from RSS feeds
 - Current chapter displayed in status bar (e.g., "Ch 2/5: Interview")
+- IPC remote control: control a running kora instance via Unix socket from another terminal
+- CLI subcommands: `kora play`, `kora pause`, `kora toggle`, `kora stop`, `kora next`, `kora prev`, `kora volume <DB>`, `kora status`
+- `kora status` returns JSON with current state, track, position, volume, and queue info
+- MPRIS / media key integration via souvlaki (Linux D-Bus, macOS MediaRemote, Windows SMTC)
+- Hardware media keys (play/pause/next/prev) control kora from keyboard or Bluetooth headphones
+- Now-playing metadata displayed in system media widgets (Control Center, playerctl, etc.)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,17 @@ dirs = "6"
 # Ctrl+C handling
 ctrlc = "3"
 
+# OS media controls (MPRIS/SMTC/MediaRemote)
+souvlaki = { version = "0.7", optional = true }
+
 # RSS/Atom feed parsing (for podcasts)
 feed-rs = "2"
 
-[dev-dependencies]
+# JSON serialization (IPC protocol)
 serde_json = "1"
+
+[features]
+default = ["media-controls"]
+media-controls = ["souvlaki"]
+
+[dev-dependencies]

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,0 +1,44 @@
+//! IPC client — connects to a running kora instance and sends a command.
+
+use anyhow::Result;
+
+use super::protocol::IpcResponse;
+
+/// Send a command to a running kora instance via IPC and return the response.
+#[cfg(unix)]
+pub fn send_command(request: &super::protocol::IpcRequest) -> Result<IpcResponse> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    use anyhow::Context;
+
+    let path = super::protocol::socket_path();
+    let stream = UnixStream::connect(&path).with_context(|| {
+        format!(
+            "Cannot connect to kora at {} — is kora running?",
+            path.display()
+        )
+    })?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+
+    let json = serde_json::to_string(request).context("Failed to serialize request")?;
+    writeln!(&stream, "{json}").context("Failed to send request")?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .context("Failed to read response")?;
+
+    let response: IpcResponse =
+        serde_json::from_str(line.trim()).context("Failed to parse response")?;
+    Ok(response)
+}
+
+/// IPC is not yet supported on non-Unix platforms.
+#[cfg(not(unix))]
+pub fn send_command(_request: &super::protocol::IpcRequest) -> Result<IpcResponse> {
+    anyhow::bail!("IPC remote control is not yet supported on this platform")
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod protocol;
+pub mod server;

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -1,0 +1,189 @@
+//! IPC protocol types — request, response, and player status.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// A command sent from an IPC client to the running kora instance.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "command")]
+pub enum IpcRequest {
+    #[serde(rename = "play")]
+    Play,
+    #[serde(rename = "pause")]
+    Pause,
+    #[serde(rename = "toggle")]
+    Toggle,
+    #[serde(rename = "stop")]
+    Stop,
+    #[serde(rename = "next")]
+    Next,
+    #[serde(rename = "prev")]
+    Prev,
+    #[serde(rename = "volume")]
+    Volume { db: f32 },
+    #[serde(rename = "status")]
+    Status,
+}
+
+/// Response sent back to the IPC client.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IpcResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PlayerStatus>,
+}
+
+/// Snapshot of the player state, returned by the `status` command.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PlayerStatus {
+    pub state: String,
+    pub track: Option<String>,
+    pub position_secs: f64,
+    pub duration_secs: f64,
+    pub volume_db: f32,
+    pub queue_position: usize,
+    pub queue_total: usize,
+}
+
+impl IpcResponse {
+    pub fn ok() -> Self {
+        Self {
+            ok: true,
+            error: None,
+            status: None,
+        }
+    }
+
+    pub fn error(msg: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            error: Some(msg.into()),
+            status: None,
+        }
+    }
+
+    pub fn with_status(status: PlayerStatus) -> Self {
+        Self {
+            ok: true,
+            error: None,
+            status: Some(status),
+        }
+    }
+}
+
+/// Return the IPC socket path for the current platform.
+#[allow(dead_code)] // Used by server/client on Unix; Windows named pipe support deferred
+pub fn socket_path() -> PathBuf {
+    #[cfg(unix)]
+    {
+        if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
+            return PathBuf::from(dir).join("kora.sock");
+        }
+        PathBuf::from("/tmp/kora.sock")
+    }
+    #[cfg(windows)]
+    {
+        PathBuf::from(r"\\.\pipe\kora")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipc_request_round_trip() {
+        let cases: Vec<IpcRequest> = vec![
+            IpcRequest::Play,
+            IpcRequest::Pause,
+            IpcRequest::Toggle,
+            IpcRequest::Stop,
+            IpcRequest::Next,
+            IpcRequest::Prev,
+            IpcRequest::Volume { db: -3.5 },
+            IpcRequest::Status,
+        ];
+        for req in &cases {
+            let json = serde_json::to_string(req).unwrap();
+            let parsed: IpcRequest = serde_json::from_str(&json).unwrap();
+            // Verify the round-trip produces the same JSON
+            let json2 = serde_json::to_string(&parsed).unwrap();
+            assert_eq!(json, json2);
+        }
+    }
+
+    #[test]
+    fn ipc_request_tagged_format() {
+        let json = serde_json::to_string(&IpcRequest::Play).unwrap();
+        assert_eq!(json, r#"{"command":"play"}"#);
+
+        let json = serde_json::to_string(&IpcRequest::Volume { db: -2.0 }).unwrap();
+        assert!(json.contains(r#""command":"volume""#));
+        assert!(json.contains(r#""db":-2.0"#));
+    }
+
+    #[test]
+    fn ipc_response_ok_serialization() {
+        let resp = IpcResponse::ok();
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(r#""ok":true"#));
+        assert!(!json.contains("error"));
+        assert!(!json.contains("status"));
+    }
+
+    #[test]
+    fn ipc_response_error_serialization() {
+        let resp = IpcResponse::error("something broke");
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(r#""ok":false"#));
+        assert!(json.contains("something broke"));
+    }
+
+    #[test]
+    fn ipc_response_with_status_serialization() {
+        let status = PlayerStatus {
+            state: "playing".to_string(),
+            track: Some("Artist — Title".to_string()),
+            position_secs: 42.5,
+            duration_secs: 180.0,
+            volume_db: -3.0,
+            queue_position: 2,
+            queue_total: 10,
+        };
+        let resp = IpcResponse::with_status(status);
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: IpcResponse = serde_json::from_str(&json).unwrap();
+        assert!(parsed.ok);
+        assert!(parsed.status.is_some());
+        let s = parsed.status.unwrap();
+        assert_eq!(s.state, "playing");
+        assert_eq!(s.track.as_deref(), Some("Artist — Title"));
+        assert!((s.position_secs - 42.5).abs() < f64::EPSILON);
+        assert_eq!(s.queue_position, 2);
+    }
+
+    #[test]
+    fn player_status_none_track() {
+        let status = PlayerStatus {
+            state: "stopped".to_string(),
+            track: None,
+            position_secs: 0.0,
+            duration_secs: 0.0,
+            volume_db: 0.0,
+            queue_position: 0,
+            queue_total: 0,
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        let parsed: PlayerStatus = serde_json::from_str(&json).unwrap();
+        assert!(parsed.track.is_none());
+    }
+
+    #[test]
+    fn socket_path_is_non_empty() {
+        let path = socket_path();
+        assert!(!path.as_os_str().is_empty());
+    }
+}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,0 +1,112 @@
+//! IPC server — listens on a Unix domain socket and forwards requests to the
+//! TUI event loop via an `mpsc` channel.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
+
+use super::protocol::{IpcRequest, IpcResponse};
+
+/// A message from the IPC server to the TUI event loop.
+///
+/// The TUI processes the request, builds a response, and sends it back
+/// through `response_tx`.
+pub struct IpcMessage {
+    pub request: IpcRequest,
+    pub response_tx: mpsc::Sender<IpcResponse>,
+}
+
+/// Start the IPC server in a background thread.
+///
+/// Returns a receiver for incoming IPC messages. On platforms without
+/// Unix socket support, returns an empty receiver (IPC is a no-op).
+pub fn start_ipc_server(stop: Arc<AtomicBool>) -> std::io::Result<mpsc::Receiver<IpcMessage>> {
+    #[cfg(unix)]
+    {
+        start_unix_server(stop)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = stop;
+        let (_tx, rx) = mpsc::channel();
+        Ok(rx)
+    }
+}
+
+#[cfg(unix)]
+fn start_unix_server(stop: Arc<AtomicBool>) -> std::io::Result<mpsc::Receiver<IpcMessage>> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel();
+    let path = super::protocol::socket_path();
+
+    // Remove stale socket file from a previous run
+    if path.exists() {
+        let _ = std::fs::remove_file(&path);
+    }
+
+    let listener = UnixListener::bind(&path)?;
+    listener.set_nonblocking(true)?;
+
+    std::thread::Builder::new()
+        .name("ipc-server".into())
+        .spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let _ = stream.set_nonblocking(false);
+                        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                        let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
+
+                        let mut reader = BufReader::new(&stream);
+                        let mut line = String::new();
+                        if reader.read_line(&mut line).is_err() {
+                            continue;
+                        }
+
+                        let request = match serde_json::from_str::<IpcRequest>(line.trim()) {
+                            Ok(req) => req,
+                            Err(e) => {
+                                let resp = IpcResponse::error(format!("Invalid JSON: {e}"));
+                                if let Ok(json) = serde_json::to_string(&resp) {
+                                    let _ = writeln!(&stream, "{json}");
+                                }
+                                continue;
+                            }
+                        };
+
+                        let (resp_tx, resp_rx) = mpsc::channel();
+                        let msg = IpcMessage {
+                            request,
+                            response_tx: resp_tx,
+                        };
+
+                        if tx.send(msg).is_err() {
+                            break; // TUI has closed
+                        }
+
+                        let response = resp_rx
+                            .recv_timeout(Duration::from_secs(5))
+                            .unwrap_or_else(|_| IpcResponse::error("Timeout waiting for response"));
+
+                        if let Ok(json) = serde_json::to_string(&response) {
+                            let _ = writeln!(&stream, "{json}");
+                        }
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                    Err(_) => {
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                }
+            }
+            // Cleanup socket file
+            let _ = std::fs::remove_file(super::protocol::socket_path());
+        })?;
+
+    Ok(rx)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@
 
 mod backend;
 mod core;
+mod ipc;
+#[cfg(feature = "media-controls")]
+mod media_controls;
 mod playback;
 mod providers;
 mod tui;
@@ -17,7 +20,7 @@ mod tui;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use crate::core::track::Track;
 use crate::playback::stream_decoder;
@@ -26,9 +29,14 @@ use crate::playback::stream_decoder;
 #[command(
     name = "kora",
     version,
-    about = "A fast, multi-source terminal audio player"
+    about = "A fast, multi-source terminal audio player",
+    args_conflicts_with_subcommands = true
 )]
 struct Cli {
+    /// Remote control subcommand
+    #[command(subcommand)]
+    command: Option<CliCommand>,
+
     /// Files, directories, or URLs to play
     #[arg(value_name = "INPUT")]
     inputs: Vec<String>,
@@ -82,6 +90,33 @@ struct Cli {
     device: Option<String>,
 }
 
+#[derive(Subcommand)]
+enum CliCommand {
+    /// Send play command to running kora instance
+    Play,
+    /// Send pause command to running kora instance
+    Pause,
+    /// Toggle play/pause on running kora instance
+    Toggle,
+    /// Send stop command to running kora instance
+    Stop,
+    /// Skip to next track
+    Next,
+    /// Skip to previous track
+    Prev,
+    /// Set volume in dB (e.g., kora volume -- -3.0)
+    Volume {
+        /// Volume level in dB
+        db: f32,
+    },
+    /// Get player status
+    Status {
+        /// Output status as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -91,6 +126,12 @@ fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    // Handle IPC subcommands (thin client mode)
+    if let Some(cmd) = cli.command {
+        return handle_ipc_command(cmd);
+    }
+
     let config = core::config::KoraConfig::load()?;
 
     tracing::debug!(
@@ -262,6 +303,41 @@ fn main() -> Result<()> {
     let player =
         playback::player::Player::new(tracks, volume, eq_preset.as_deref(), rg_mode, device_name)?;
     tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
+
+    Ok(())
+}
+
+fn handle_ipc_command(cmd: CliCommand) -> Result<()> {
+    use crate::ipc::client::send_command;
+    use crate::ipc::protocol::IpcRequest;
+
+    let is_status = matches!(cmd, CliCommand::Status { .. });
+
+    let request = match cmd {
+        CliCommand::Play => IpcRequest::Play,
+        CliCommand::Pause => IpcRequest::Pause,
+        CliCommand::Toggle => IpcRequest::Toggle,
+        CliCommand::Stop => IpcRequest::Stop,
+        CliCommand::Next => IpcRequest::Next,
+        CliCommand::Prev => IpcRequest::Prev,
+        CliCommand::Volume { db } => IpcRequest::Volume { db },
+        CliCommand::Status { .. } => IpcRequest::Status,
+    };
+
+    let response = send_command(&request)?;
+
+    if is_status {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&response).context("Failed to format response")?
+        );
+    } else if !response.ok {
+        eprintln!(
+            "Error: {}",
+            response.error.as_deref().unwrap_or("unknown error")
+        );
+        std::process::exit(1);
+    }
 
     Ok(())
 }

--- a/src/media_controls.rs
+++ b/src/media_controls.rs
@@ -1,0 +1,159 @@
+//! Cross-platform media key integration via souvlaki (MPRIS/SMTC/MediaRemote).
+//!
+//! This module bridges the OS media controls to kora's playback commands.
+//! It is gated behind the `media-controls` feature flag so the player
+//! works even on systems without D-Bus or other platform requirements.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use souvlaki::{
+    MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
+};
+
+use crate::playback::player::PlayerCommand;
+
+/// On Windows, retrieve the console window handle for SMTC integration.
+#[cfg(target_os = "windows")]
+fn get_console_hwnd() -> Option<*mut std::ffi::c_void> {
+    unsafe extern "system" {
+        fn GetConsoleWindow() -> *mut std::ffi::c_void;
+    }
+    let hwnd = unsafe { GetConsoleWindow() };
+    if hwnd.is_null() { None } else { Some(hwnd) }
+}
+
+/// Initialize platform media controls and return a receiver for media key events.
+///
+/// Returns `None` if initialization fails (e.g. no D-Bus on Linux, headless server).
+pub fn init_media_controls() -> Option<(MediaControls, mpsc::Receiver<MediaControlEvent>)> {
+    let (tx, rx) = mpsc::channel();
+
+    #[cfg(target_os = "windows")]
+    let hwnd = get_console_hwnd();
+    #[cfg(not(target_os = "windows"))]
+    let hwnd: Option<*mut std::ffi::c_void> = None;
+
+    let config = PlatformConfig {
+        dbus_name: "kora",
+        display_name: "Kora",
+        hwnd,
+    };
+
+    let mut controls = match MediaControls::new(config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Media controls unavailable: {e:?}");
+            return None;
+        }
+    };
+
+    if let Err(e) = controls.attach(move |event: MediaControlEvent| {
+        let _ = tx.send(event);
+    }) {
+        tracing::warn!("Failed to attach media controls handler: {e:?}");
+        return None;
+    }
+
+    Some((controls, rx))
+}
+
+/// Update the OS now-playing metadata display.
+pub fn update_metadata(
+    controls: &mut MediaControls,
+    title: Option<&str>,
+    artist: Option<&str>,
+    album: Option<&str>,
+    duration: Option<Duration>,
+) {
+    let metadata = MediaMetadata {
+        title,
+        artist,
+        album,
+        cover_url: None,
+        duration,
+    };
+    if let Err(e) = controls.set_metadata(metadata) {
+        tracing::debug!("Failed to update media metadata: {e:?}");
+    }
+}
+
+/// Update the OS playback state indicator.
+pub fn update_playback(controls: &mut MediaControls, playing: bool, position: Option<Duration>) {
+    let progress = position.map(MediaPosition);
+    let playback = if playing {
+        MediaPlayback::Playing { progress }
+    } else {
+        MediaPlayback::Paused { progress }
+    };
+    if let Err(e) = controls.set_playback(playback) {
+        tracing::debug!("Failed to update media playback state: {e:?}");
+    }
+}
+
+/// Map a souvlaki `MediaControlEvent` to a kora `PlayerCommand`.
+///
+/// Returns `None` for events we don't handle (Raise, OpenUri, etc.).
+pub fn map_media_event(event: &MediaControlEvent) -> Option<PlayerCommand> {
+    match event {
+        MediaControlEvent::Play | MediaControlEvent::Pause | MediaControlEvent::Toggle => {
+            Some(PlayerCommand::PlayPause)
+        }
+        MediaControlEvent::Next => Some(PlayerCommand::NextTrack),
+        MediaControlEvent::Previous => Some(PlayerCommand::PrevTrack),
+        MediaControlEvent::Stop => Some(PlayerCommand::Stop),
+        MediaControlEvent::Quit => Some(PlayerCommand::Quit),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use souvlaki::MediaControlEvent;
+
+    #[test]
+    fn test_map_play_events() {
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Play),
+            Some(PlayerCommand::PlayPause)
+        ));
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Pause),
+            Some(PlayerCommand::PlayPause)
+        ));
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Toggle),
+            Some(PlayerCommand::PlayPause)
+        ));
+    }
+
+    #[test]
+    fn test_map_navigation_events() {
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Next),
+            Some(PlayerCommand::NextTrack)
+        ));
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Previous),
+            Some(PlayerCommand::PrevTrack)
+        ));
+    }
+
+    #[test]
+    fn test_map_stop_and_quit() {
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Stop),
+            Some(PlayerCommand::Stop)
+        ));
+        assert!(matches!(
+            map_media_event(&MediaControlEvent::Quit),
+            Some(PlayerCommand::Quit)
+        ));
+    }
+
+    #[test]
+    fn test_map_unhandled_events() {
+        assert!(map_media_event(&MediaControlEvent::Raise).is_none());
+    }
+}

--- a/src/playback/player.rs
+++ b/src/playback/player.rs
@@ -97,6 +97,8 @@ pub enum PlayerCommand {
     #[allow(dead_code)] // Available for CLI/IPC device listing
     ListDevices,
     SetDevice(String),
+    /// Set absolute volume in dB (for IPC remote control).
+    SetVolume(f32),
     /// Open the podcast browser view (handled in TUI layer).
     #[allow(dead_code)]
     OpenPodcasts,
@@ -642,6 +644,12 @@ impl Player {
             }
             PlayerCommand::SetDevice(name) => {
                 self.device_name = Some(name);
+                PlayerAction::None
+            }
+            PlayerCommand::SetVolume(db) => {
+                self.volume = Volume(db.clamp(-30.0, 6.0));
+                self.shared_volume
+                    .store(self.volume.as_linear().to_bits(), Ordering::Relaxed);
                 PlayerAction::None
             }
             PlayerCommand::OpenPodcasts | PlayerCommand::AddPodcastFeed(_) => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -89,6 +89,21 @@ pub fn run_with_theme(
         .unwrap_or(0);
     let mut theme = themes[theme_index].clone();
     let mut terminal = ratatui::init();
+
+    // Start IPC server for remote control
+    let ipc_stop = Arc::new(AtomicBool::new(false));
+    let ipc_rx = match crate::ipc::server::start_ipc_server(ipc_stop.clone()) {
+        Ok(rx) => Some(rx),
+        Err(e) => {
+            tracing::warn!("Failed to start IPC server: {e}");
+            None
+        }
+    };
+
+    // Initialize OS media controls (MPRIS/SMTC/MediaRemote)
+    #[cfg(feature = "media-controls")]
+    let mut media_controls = crate::media_controls::init_media_controls();
+
     let result = run_loop(
         &mut terminal,
         &mut player,
@@ -96,7 +111,13 @@ pub fn run_with_theme(
         &mut theme,
         &themes,
         &mut theme_index,
+        #[cfg(feature = "media-controls")]
+        &mut media_controls,
+        ipc_rx.as_ref(),
     );
+
+    // Stop IPC server
+    ipc_stop.store(true, Ordering::Relaxed);
 
     // Restore terminal
     ratatui::restore();
@@ -105,6 +126,7 @@ pub fn run_with_theme(
     result
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_loop(
     terminal: &mut DefaultTerminal,
     player: &mut Player,
@@ -112,6 +134,11 @@ fn run_loop(
     theme: &mut Theme,
     themes: &[Theme],
     theme_index: &mut usize,
+    #[cfg(feature = "media-controls")] media_controls: &mut Option<(
+        souvlaki::MediaControls,
+        std::sync::mpsc::Receiver<souvlaki::MediaControlEvent>,
+    )>,
+    ipc_rx: Option<&std::sync::mpsc::Receiver<crate::ipc::server::IpcMessage>>,
 ) -> Result<()> {
     let tick_rate = Duration::from_millis(100);
     let save_interval = Duration::from_secs(30);
@@ -126,6 +153,21 @@ fn run_loop(
     // Gapless playback state
     let mut gapless_played_next: Option<Arc<AtomicBool>> = None;
     let mut pre_decode_triggered = false;
+
+    // Track the last known track index + state for media controls updates
+    #[cfg(feature = "media-controls")]
+    let mut last_media_track_index: Option<usize> = None;
+    #[cfg(feature = "media-controls")]
+    let mut last_media_playing: Option<bool> = None;
+
+    // Send initial metadata/playback state to OS media controls
+    #[cfg(feature = "media-controls")]
+    sync_media_controls(
+        player,
+        media_controls,
+        &mut last_media_track_index,
+        &mut last_media_playing,
+    );
 
     loop {
         // Draw
@@ -230,6 +272,53 @@ fn run_loop(
                 tracing::warn!("Failed to auto-save session: {e}");
             }
             last_save = Instant::now();
+        }
+
+        // Process OS media key events (MPRIS / SMTC / MediaRemote)
+        #[cfg(feature = "media-controls")]
+        if let Some((controls, rx)) = media_controls.as_mut() {
+            while let Ok(event) = rx.try_recv() {
+                if let Some(cmd) = crate::media_controls::map_media_event(&event) {
+                    let action = player.handle_command(cmd);
+                    if matches!(action, PlayerAction::Quit) {
+                        if let Err(e) = player.save_session() {
+                            tracing::warn!("Failed to save session on quit: {e}");
+                        }
+                        return Ok(());
+                    }
+                    handle_action(
+                        action,
+                        player,
+                        playback_handle,
+                        &mut gapless_played_next,
+                        &mut pre_decode_triggered,
+                    )?;
+                }
+            }
+            let _ = controls;
+        }
+
+        // Sync media controls state after any changes
+        #[cfg(feature = "media-controls")]
+        sync_media_controls(
+            player,
+            media_controls,
+            &mut last_media_track_index,
+            &mut last_media_playing,
+        );
+
+        // Process IPC remote control messages
+        if let Some(rx) = ipc_rx {
+            while let Ok(msg) = rx.try_recv() {
+                let response = handle_ipc_request(
+                    &msg.request,
+                    player,
+                    playback_handle,
+                    &mut gapless_played_next,
+                    &mut pre_decode_triggered,
+                );
+                let _ = msg.response_tx.send(response);
+            }
         }
 
         // Poll for keyboard input
@@ -519,6 +608,157 @@ fn run_loop(
                 )?;
             }
         }
+    }
+}
+
+/// Sync OS media controls with current player state (metadata + playback).
+/// Only sends updates when something actually changed to avoid unnecessary IPC.
+#[cfg(feature = "media-controls")]
+fn sync_media_controls(
+    player: &Player,
+    media_controls: &mut Option<(
+        souvlaki::MediaControls,
+        std::sync::mpsc::Receiver<souvlaki::MediaControlEvent>,
+    )>,
+    last_track_index: &mut Option<usize>,
+    last_playing: &mut Option<bool>,
+) {
+    let Some((controls, _)) = media_controls.as_mut() else {
+        return;
+    };
+
+    let (current_idx, _) = player.queue_position();
+    let is_playing = player.state() == PlaybackState::Playing;
+
+    // Update metadata when the track changes
+    if *last_track_index != Some(current_idx) {
+        *last_track_index = Some(current_idx);
+        if let Some(track) = player.current_track() {
+            let meta = track.metadata.as_ref();
+            crate::media_controls::update_metadata(
+                controls,
+                meta.and_then(|m| m.title.as_deref()),
+                meta.and_then(|m| m.artist.as_deref()),
+                meta.and_then(|m| m.album.as_deref()),
+                meta.and_then(|m| m.duration),
+            );
+        }
+    }
+
+    // Update playback state when it changes
+    if *last_playing != Some(is_playing) {
+        *last_playing = Some(is_playing);
+        let position = if player.duration().as_secs() > 0 {
+            Some(player.current_position())
+        } else {
+            None
+        };
+        crate::media_controls::update_playback(controls, is_playing, position);
+    }
+}
+
+/// Process a single IPC request and return a response.
+fn handle_ipc_request(
+    request: &crate::ipc::protocol::IpcRequest,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+    gapless_played_next: &mut Option<Arc<AtomicBool>>,
+    pre_decode_triggered: &mut bool,
+) -> crate::ipc::protocol::IpcResponse {
+    use crate::ipc::protocol::{IpcRequest, IpcResponse, PlayerStatus};
+
+    match request {
+        IpcRequest::Status => {
+            let state_str = match player.state() {
+                PlaybackState::Playing => "playing",
+                PlaybackState::Paused => "paused",
+                PlaybackState::Stopped => "stopped",
+            };
+            let (pos, total) = player.queue_position();
+            IpcResponse::with_status(PlayerStatus {
+                state: state_str.to_string(),
+                track: player.current_track().map(|t| t.display_name()),
+                position_secs: player.current_position().as_secs_f64(),
+                duration_secs: player.duration().as_secs_f64(),
+                volume_db: player.volume_db(),
+                queue_position: pos,
+                queue_total: total,
+            })
+        }
+        IpcRequest::Play if player.state() != PlaybackState::Playing => ipc_dispatch(
+            PlayerCommand::PlayPause,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Play => IpcResponse::ok(),
+        IpcRequest::Pause if player.state() == PlaybackState::Playing => ipc_dispatch(
+            PlayerCommand::PlayPause,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Pause => IpcResponse::ok(),
+        IpcRequest::Toggle => ipc_dispatch(
+            PlayerCommand::PlayPause,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Stop => ipc_dispatch(
+            PlayerCommand::Stop,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Next => ipc_dispatch(
+            PlayerCommand::NextTrack,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Prev => ipc_dispatch(
+            PlayerCommand::PrevTrack,
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+        IpcRequest::Volume { db } => ipc_dispatch(
+            PlayerCommand::SetVolume(*db),
+            player,
+            playback_handle,
+            gapless_played_next,
+            pre_decode_triggered,
+        ),
+    }
+}
+
+/// Execute a player command and convert the result to an IPC response.
+fn ipc_dispatch(
+    cmd: PlayerCommand,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+    gapless_played_next: &mut Option<Arc<AtomicBool>>,
+    pre_decode_triggered: &mut bool,
+) -> crate::ipc::protocol::IpcResponse {
+    use crate::ipc::protocol::IpcResponse;
+
+    let action = player.handle_command(cmd);
+    match handle_action(
+        action,
+        player,
+        playback_handle,
+        gapless_played_next,
+        pre_decode_triggered,
+    ) {
+        Ok(()) => IpcResponse::ok(),
+        Err(e) => IpcResponse::error(e.to_string()),
     }
 }
 


### PR DESCRIPTION
## Description

Add IPC remote control and MPRIS/media key integration — kora is now scriptable and system-integrated.

### What's included

- **IPC remote control**: A Unix domain socket server runs inside the player process. Control a running kora from another terminal with subcommands: `kora play`, `kora pause`, `kora toggle`, `kora stop`, `kora next`, `kora prev`, `kora volume <DB>`, `kora status`. The `status` command returns JSON with current state, track, position, volume, and queue info — perfect for scripting and status bars. Uses JSON-over-socket protocol with one connection per command. `#[cfg(unix)]` gated (Windows named pipe support deferred).
- **MPRIS / media key integration**: Cross-platform media controls via the `souvlaki` crate (optional `media-controls` feature, enabled by default). On Linux, kora appears as an MPRIS player — compatible with `playerctl`, KDE, and GNOME media widgets. On macOS, integrates with Control Center and Touch Bar. On Windows, uses System Media Transport Controls. Hardware media keys (play/pause/next/prev on keyboards and Bluetooth headphones) work out of the box. Track metadata (title, artist, album) and playback state are synced to the OS.
- **CI update**: Added `libdbus-1-dev` to Linux CI for souvlaki/MPRIS compilation.

## Related Issues

Closes #32, closes #33

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / infrastructure

## Module

- [x] `playback/` — Decode, DSP, state machine
- [x] `ipc/` — Remote control
- [x] `tui/` — Terminal UI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (243 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)