### PR TITLE
feat: add shell completions and headless daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MPRIS / media key integration via souvlaki (Linux D-Bus, macOS MediaRemote, Windows SMTC)
 - Hardware media keys (play/pause/next/prev) control kora from keyboard or Bluetooth headphones
 - Now-playing metadata displayed in system media widgets (Control Center, playerctl, etc.)
+- Shell completions: `kora completions bash|zsh|fish|powershell` generates shell-specific completions
+- Headless/daemon mode: `kora --daemon` runs without TUI, controlled entirely via IPC subcommands
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ crossterm = "0.29"
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # Config & serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ cargo install --path .
 - **macOS**: No extra dependencies (CoreAudio)
 - **Windows**: No extra dependencies (WASAPI)
 
+## Shell Completions
+
+Generate completions for your shell:
+
+```sh
+# Bash
+kora completions bash > ~/.local/share/bash-completion/completions/kora
+
+# Zsh
+kora completions zsh > ~/.zfunc/_kora
+
+# Fish
+kora completions fish > ~/.config/fish/completions/kora.fish
+
+# PowerShell
+kora completions powershell > _kora.ps1
+```
+
 ## Status
 
 🚧 **Early development** — Phase 2 (Daily Driver). Local files, internet radio, and HTTP streams are working. See [ROADMAP.md](ROADMAP.md) for the full plan.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,255 @@
+//! Daemon mode — headless event loop controlled via IPC.
+//!
+//! Runs the player without a TUI, printing minimal status to stdout.
+//! Remote control is available via `kora pause`, `kora next`, etc.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::ipc::protocol::{IpcRequest, IpcResponse, PlayerStatus};
+use crate::ipc::server::IpcMessage;
+use crate::playback::player::{PlaybackState, Player, PlayerAction, PlayerCommand};
+
+/// Run the player in daemon (headless) mode.
+///
+/// Starts the IPC server, plays the first track, and enters a polling loop
+/// that handles IPC commands and track transitions until stopped.
+pub fn run_daemon(mut player: Player) -> Result<()> {
+    // Start IPC server for remote control
+    let ipc_stop = Arc::new(AtomicBool::new(false));
+    let ipc_rx = match crate::ipc::server::start_ipc_server(ipc_stop.clone()) {
+        Ok(rx) => Some(rx),
+        Err(e) => {
+            tracing::warn!("Failed to start IPC server: {e}");
+            None
+        }
+    };
+
+    // Load and play the first track
+    let mut playback_handle: Option<std::thread::JoinHandle<Result<()>>> = None;
+    if !player.tracks().is_empty() {
+        player.play_current()?;
+        playback_handle = player.start_playback();
+        player.mark_playback_started();
+    }
+
+    println!("kora daemon started (PID {})", std::process::id());
+    if ipc_rx.is_some() {
+        println!("Control with: kora pause, kora next, kora status");
+    } else {
+        println!("IPC not available — playing tracks sequentially");
+    }
+    print_now_playing(&player);
+
+    loop {
+        // Process IPC commands
+        if let Some(ref rx) = ipc_rx {
+            while let Ok(msg) = rx.try_recv() {
+                let (response, should_quit) =
+                    handle_ipc_message(&msg, &mut player, &mut playback_handle);
+                let _ = msg.response_tx.send(response);
+                if should_quit {
+                    stop_daemon(&player, &ipc_stop, playback_handle);
+                    return Ok(());
+                }
+            }
+        }
+
+        // Check if playback thread finished (track ended naturally)
+        if let Some(ref handle) = playback_handle {
+            if handle.is_finished() {
+                if let Some(h) = playback_handle.take() {
+                    let _ = h.join();
+                }
+                let action = player.on_track_finished();
+                match action {
+                    PlayerAction::LoadAndPlay => {
+                        player.play_current()?;
+                        playback_handle = player.start_playback();
+                        player.mark_playback_started();
+                        print_now_playing(&player);
+                    }
+                    PlayerAction::GaplessTransition => {
+                        if let Some(pre) = player.take_next_track_samples() {
+                            player.play_predecoded(pre);
+                            playback_handle = player.start_playback();
+                            player.mark_playback_started();
+                            print_now_playing(&player);
+                        }
+                    }
+                    PlayerAction::Quit | PlayerAction::None => {
+                        // All tracks played or queue empty
+                        stop_daemon(&player, &ipc_stop, playback_handle);
+                        return Ok(());
+                    }
+                }
+            }
+        } else if player.state() == PlaybackState::Stopped && ipc_rx.is_none() {
+            // No IPC and no playback — nothing to do
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    stop_daemon(&player, &ipc_stop, playback_handle);
+    Ok(())
+}
+
+/// Handle a single IPC message, returning the response and whether to quit.
+fn handle_ipc_message(
+    msg: &IpcMessage,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+) -> (IpcResponse, bool) {
+    match &msg.request {
+        IpcRequest::Status => {
+            let state_str = match player.state() {
+                PlaybackState::Playing => "playing",
+                PlaybackState::Paused => "paused",
+                PlaybackState::Stopped => "stopped",
+            };
+            let (pos, total) = player.queue_position();
+            let resp = IpcResponse::with_status(PlayerStatus {
+                state: state_str.to_string(),
+                track: player.current_track().map(|t| t.display_name()),
+                position_secs: player.current_position().as_secs_f64(),
+                duration_secs: player.duration().as_secs_f64(),
+                volume_db: player.volume_db(),
+                queue_position: pos,
+                queue_total: total,
+            });
+            (resp, false)
+        }
+        IpcRequest::Play if player.state() != PlaybackState::Playing => {
+            dispatch_command(PlayerCommand::PlayPause, player, playback_handle)
+        }
+        IpcRequest::Play => (IpcResponse::ok(), false),
+        IpcRequest::Pause if player.state() == PlaybackState::Playing => {
+            dispatch_command(PlayerCommand::PlayPause, player, playback_handle)
+        }
+        IpcRequest::Pause => (IpcResponse::ok(), false),
+        IpcRequest::Toggle => dispatch_command(PlayerCommand::PlayPause, player, playback_handle),
+        IpcRequest::Stop => {
+            let (resp, _) = dispatch_command(PlayerCommand::Stop, player, playback_handle);
+            (resp, true)
+        }
+        IpcRequest::Next => {
+            let result = dispatch_command(PlayerCommand::NextTrack, player, playback_handle);
+            print_now_playing(player);
+            result
+        }
+        IpcRequest::Prev => {
+            let result = dispatch_command(PlayerCommand::PrevTrack, player, playback_handle);
+            print_now_playing(player);
+            result
+        }
+        IpcRequest::Volume { db } => {
+            dispatch_command(PlayerCommand::SetVolume(*db), player, playback_handle)
+        }
+    }
+}
+
+/// Execute a player command and produce an IPC response.
+fn dispatch_command(
+    cmd: PlayerCommand,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+) -> (IpcResponse, bool) {
+    let action = player.handle_command(cmd);
+    match handle_action(action, player, playback_handle) {
+        Ok(quit) => (IpcResponse::ok(), quit),
+        Err(e) => (IpcResponse::error(e.to_string()), false),
+    }
+}
+
+/// Execute a `PlayerAction` — returns `true` if the daemon should quit.
+fn handle_action(
+    action: PlayerAction,
+    player: &mut Player,
+    playback_handle: &mut Option<std::thread::JoinHandle<Result<()>>>,
+) -> Result<bool> {
+    match action {
+        PlayerAction::None => Ok(false),
+        PlayerAction::LoadAndPlay => {
+            if let Some(h) = playback_handle.take() {
+                let _ = h.join();
+            }
+            let current_idx = player.current_index();
+            if let Some(pre) = player.take_next_track_samples() {
+                if pre.track_index == current_idx {
+                    player.play_predecoded(pre);
+                } else {
+                    player.play_current()?;
+                }
+            } else {
+                player.play_current()?;
+            }
+            *playback_handle = player.start_playback();
+            player.mark_playback_started();
+            Ok(false)
+        }
+        PlayerAction::GaplessTransition => {
+            if let Some(h) = playback_handle.take() {
+                let _ = h.join();
+            }
+            if let Some(pre) = player.take_next_track_samples() {
+                player.play_predecoded(pre);
+                *playback_handle = player.start_playback();
+            } else {
+                player.play_current()?;
+                *playback_handle = player.start_playback();
+            }
+            player.mark_playback_started();
+            Ok(false)
+        }
+        PlayerAction::Quit => Ok(true),
+    }
+}
+
+fn print_now_playing(player: &Player) {
+    if let Some(track) = player.current_track() {
+        println!("Playing: {}", track.display_name());
+    }
+}
+
+fn stop_daemon(
+    player: &Player,
+    ipc_stop: &Arc<AtomicBool>,
+    playback_handle: Option<std::thread::JoinHandle<Result<()>>>,
+) {
+    player.save_session().ok();
+    ipc_stop.store(true, Ordering::Relaxed);
+    if let Some(h) = playback_handle {
+        let _ = h.join();
+    }
+    println!("kora daemon stopped");
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    /// Verify `--daemon` flag is accepted by the CLI parser.
+    #[test]
+    fn daemon_flag_accepted() {
+        let cli = crate::Cli::try_parse_from(["kora", "--daemon", "file.mp3"]);
+        assert!(cli.is_ok(), "Failed to parse --daemon flag: {cli:?}");
+        let cli = cli.unwrap();
+        assert!(cli.daemon);
+        assert_eq!(cli.inputs, vec!["file.mp3"]);
+    }
+
+    /// Verify `--daemon` without inputs is accepted.
+    #[test]
+    fn daemon_flag_without_inputs() {
+        let cli = crate::Cli::try_parse_from(["kora", "--daemon"]);
+        assert!(cli.is_ok());
+        let cli = cli.unwrap();
+        assert!(cli.daemon);
+        assert!(cli.inputs.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 
 mod backend;
 mod core;
+mod daemon;
 mod ipc;
 #[cfg(feature = "media-controls")]
 mod media_controls;
@@ -20,19 +21,19 @@ mod tui;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 use crate::core::track::Track;
 use crate::playback::stream_decoder;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(
     name = "kora",
     version,
     about = "A fast, multi-source terminal audio player",
     args_conflicts_with_subcommands = true
 )]
-struct Cli {
+pub(crate) struct Cli {
     /// Remote control subcommand
     #[command(subcommand)]
     command: Option<CliCommand>,
@@ -88,9 +89,13 @@ struct Cli {
     /// Select audio output device by name (case-insensitive substring match)
     #[arg(long, value_name = "NAME")]
     device: Option<String>,
+
+    /// Run in daemon mode (no TUI, controlled via IPC)
+    #[arg(long)]
+    daemon: bool,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum CliCommand {
     /// Send play command to running kora instance
     Play,
@@ -115,6 +120,11 @@ enum CliCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 fn main() -> Result<()> {
@@ -126,6 +136,12 @@ fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    // Handle completions subcommand (not an IPC command)
+    if let Some(CliCommand::Completions { shell }) = cli.command {
+        clap_complete::generate(shell, &mut Cli::command(), "kora", &mut std::io::stdout());
+        return Ok(());
+    }
 
     // Handle IPC subcommands (thin client mode)
     if let Some(cmd) = cli.command {
@@ -299,10 +315,16 @@ fn main() -> Result<()> {
 
     tracing::info!("Playing {} track(s)", tracks.len());
 
-    // Launch TUI player
     let player =
         playback::player::Player::new(tracks, volume, eq_preset.as_deref(), rg_mode, device_name)?;
-    tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
+
+    if cli.daemon {
+        // Daemon mode: headless, IPC-controlled
+        daemon::run_daemon(player)?;
+    } else {
+        // TUI mode (default)
+        tui::app::run_with_theme(player, cli.no_restore, theme_name.as_deref())?;
+    }
 
     Ok(())
 }
@@ -322,6 +344,7 @@ fn handle_ipc_command(cmd: CliCommand) -> Result<()> {
         CliCommand::Prev => IpcRequest::Prev,
         CliCommand::Volume { db } => IpcRequest::Volume { db },
         CliCommand::Status { .. } => IpcRequest::Status,
+        CliCommand::Completions { .. } => unreachable!("handled before IPC dispatch"),
     };
 
     let response = send_command(&request)?;
@@ -340,4 +363,66 @@ fn handle_ipc_command(cmd: CliCommand) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn completions_bash() {
+        let mut buf = Vec::new();
+        clap_complete::generate(
+            clap_complete::Shell::Bash,
+            &mut Cli::command(),
+            "kora",
+            &mut buf,
+        );
+        assert!(!buf.is_empty(), "bash completions should not be empty");
+    }
+
+    #[test]
+    fn completions_zsh() {
+        let mut buf = Vec::new();
+        clap_complete::generate(
+            clap_complete::Shell::Zsh,
+            &mut Cli::command(),
+            "kora",
+            &mut buf,
+        );
+        assert!(!buf.is_empty(), "zsh completions should not be empty");
+    }
+
+    #[test]
+    fn completions_fish() {
+        let mut buf = Vec::new();
+        clap_complete::generate(
+            clap_complete::Shell::Fish,
+            &mut Cli::command(),
+            "kora",
+            &mut buf,
+        );
+        assert!(!buf.is_empty(), "fish completions should not be empty");
+    }
+
+    #[test]
+    fn completions_powershell() {
+        let mut buf = Vec::new();
+        clap_complete::generate(
+            clap_complete::Shell::PowerShell,
+            &mut Cli::command(),
+            "kora",
+            &mut buf,
+        );
+        assert!(
+            !buf.is_empty(),
+            "powershell completions should not be empty"
+        );
+    }
 }


### PR DESCRIPTION
## Description

Add shell completions and headless daemon mode — completing Phase 5 (Power User & Ecosystem).

### What's included

- **Shell completions**: `kora completions bash|zsh|fish|powershell` generates shell-specific completion scripts via `clap_complete`. README includes install instructions for all four shells.
- **Headless/daemon mode**: `kora --daemon song.mp3` starts playback without the TUI, controlled entirely via IPC subcommands (`kora pause`, `kora next`, `kora status`, etc.). Prints track changes to stdout. Useful for scripting, tmux sessions, remote control, and running kora as a background service. Session state is saved on exit.

## Related Issues

Closes #34, closes #35

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Module

- [x] `tui/` — Terminal UI
- [x] `ipc/` — Remote control

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (250 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have updated CHANGELOG.md (if user-facing changes)