### PR TITLE
chore: group Dependabot updates into per-ecosystem PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -25,3 +29,7 @@ updates:
       - "ci"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

Dependabot currently opens a separate pull request for every dependency update, which creates noise and review overhead. Grouping updates per ecosystem keeps related bumps together so they can be reviewed and merged as a single unit.

## What

Adds a `groups:` block to each `package-ecosystem` entry in `.github/dependabot.yml`:

- `cargo` updates are bundled into one PR via `patterns: ["*"]`
- `github-actions` updates are bundled into one PR via `patterns: ["*"]`

All existing keys (schedule, commit-message, labels, open-pull-requests-limit) are preserved unchanged.

## Notes

Config-only change. No code or runtime behavior is affected.